### PR TITLE
chore: add .eslintignore to avoid linting non-code files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,27 @@
+# macOS
+.DS_Store
+**/.DS_Store
+
+# build/artifacts
+.next/
+node_modules/
+**/*.tsbuildinfo
+
+# docs/assets
+docs/
+public/
+scripts/
+
+# non-js sources that can be accidentally linted
+**/*.md
+**/*.txt
+**/*.svg
+**/*.ico
+**/*.css
+**/*.sh
+**/*.yml
+**/*.yaml
+**/*.json
+
+# ad-hoc backups
+**/*.bak.*


### PR DESCRIPTION
What
- Add .eslintignore to exclude docs/assets/non-code files from eslint

Why
- Prevent parsing errors from markdown/svg/shell/json/.DS_Store when config changes

Verify
- npm run lint
- npm run build
- ./scripts/check-uiux-sources.sh
