### PR TITLE
Proxy API routes via Next + OpenAPI typing cleanup

### DIFF
--- a/app/api/_proxy.ts
+++ b/app/api/_proxy.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const runtime = "nodejs";
+
+function backendBaseUrl(): string {
+  const base =
+    process.env.BACKEND_URL ||
+    process.env.NEXT_PUBLIC_BACKEND_URL ||
+    process.env.NEXT_PUBLIC_API_BASE_URL ||
+    "";
+  if (!base) throw new Error("BACKEND_URL (or NEXT_PUBLIC_BACKEND_URL) is not set");
+  return base.replace(/\/+$/, "");
+}
+
+function withTimeout(ms: number) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), ms);
+  return { controller, timer };
+}
+
+export async function proxyToBackend(req: NextRequest, endpoint: string) {
+  const backend = backendBaseUrl();
+  const incoming = new URL(req.url);
+
+  const target = new URL(`${backend}/api/${endpoint}`);
+  target.search = incoming.search;
+
+  const { controller, timer } = withTimeout(120_000);
+
+  try {
+    const headers = new Headers(req.headers);
+    headers.delete("host");
+    headers.delete("connection");
+    headers.delete("content-length");
+
+    const init: RequestInit = {
+      method: req.method,
+      headers,
+      signal: controller.signal,
+    };
+
+    if (req.method !== "GET" && req.method !== "HEAD") {
+      init.body = await req.arrayBuffer();
+    }
+
+    const res = await fetch(target.toString(), init);
+
+    const outHeaders = new Headers(res.headers);
+    outHeaders.delete("content-encoding");
+
+    return new NextResponse(res.body, { status: res.status, headers: outHeaders });
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : String(e);
+
+    return NextResponse.json(
+      { error: "proxy_failed", message, endpoint, target: target.toString() },
+      { status: 502 },
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/app/api/match-snapshot-with-xml/route.ts
+++ b/app/api/match-snapshot-with-xml/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest } from "next/server";
+import { proxyToBackend } from "../_proxy";
+
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  return proxyToBackend(req, "match-snapshot-with-xml");
+}
+
+export async function POST(req: NextRequest) {
+  return proxyToBackend(req, "match-snapshot-with-xml");
+}

--- a/app/api/match_snapshot_with_xml/route.ts
+++ b/app/api/match_snapshot_with_xml/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest } from "next/server";
+import { proxyToBackend } from "../_proxy";
+
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  return proxyToBackend(req, "match_snapshot_with_xml");
+}
+
+export async function POST(req: NextRequest) {
+  return proxyToBackend(req, "match_snapshot_with_xml");
+}

--- a/app/api/playlist-with-rekordbox-upload/route.ts
+++ b/app/api/playlist-with-rekordbox-upload/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest } from "next/server";
+import { proxyToBackend } from "../_proxy";
+
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  return proxyToBackend(req, "playlist-with-rekordbox-upload");
+}
+
+export async function POST(req: NextRequest) {
+  return proxyToBackend(req, "playlist-with-rekordbox-upload");
+}

--- a/app/api/playlist-with-rekordbox/route.ts
+++ b/app/api/playlist-with-rekordbox/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest } from "next/server";
+import { proxyToBackend } from "../_proxy";
+
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  return proxyToBackend(req, "playlist-with-rekordbox");
+}
+
+export async function POST(req: NextRequest) {
+  return proxyToBackend(req, "playlist-with-rekordbox");
+}

--- a/app/api/playlist/route.ts
+++ b/app/api/playlist/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest } from "next/server";
+import { proxyToBackend } from "../_proxy";
+
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  return proxyToBackend(req, "playlist");
+}
+
+export async function POST(req: NextRequest) {
+  return proxyToBackend(req, "playlist");
+}

--- a/app/api/playlist_with_rekordbox/route.ts
+++ b/app/api/playlist_with_rekordbox/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest } from "next/server";
+import { proxyToBackend } from "../_proxy";
+
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  return proxyToBackend(req, "playlist_with_rekordbox");
+}
+
+export async function POST(req: NextRequest) {
+  return proxyToBackend(req, "playlist_with_rekordbox");
+}

--- a/app/api/playlist_with_rekordbox_upload/route.ts
+++ b/app/api/playlist_with_rekordbox_upload/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest } from "next/server";
+import { proxyToBackend } from "../_proxy";
+
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  return proxyToBackend(req, "playlist_with_rekordbox_upload");
+}
+
+export async function POST(req: NextRequest) {
+  return proxyToBackend(req, "playlist_with_rekordbox_upload");
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,3 @@
+/** @type {import("next").NextConfig} */
+const nextConfig = {};
+export default nextConfig;


### PR DESCRIPTION
## Summary
- Proxy /api/* via Next route handlers to backend (avoids CORS + fixes 404)
- OpenAPI transport types + normalize layer; state kept domain-only
- Add Buy Me a Coffee link in footer (URL via env)

## Notes
- Requires Vercel env: NEXT_PUBLIC_BACKEND_URL or BACKEND_URL, and NEXT_PUBLIC_BMC_URL
