### PR TITLE
fix(frontend): route /api via same-origin Next API to avoid CORS

### DIFF
--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -105,8 +105,9 @@ const DEFAULT_BACKEND_ORIGIN = [
 
 function resolveApiUrl(path: string): string {
   if (path.startsWith("http")) return path;
+  // In the browser, prefer same-origin Next.js API routes (/api/*).
+  if (path.startsWith("/api/")) return path;
   if (!BASE_URL) return path;
-  if (path.startsWith("/api/")) return `${BASE_URL}${path}`;
   return path;
 }
 

--- a/lib/api/playlist.ts
+++ b/lib/api/playlist.ts
@@ -32,7 +32,7 @@ export type MatchSnapshotWithXmlResponse = {
   [key: string]: unknown;
 };
 
-const DIRECT_BACKEND_ORIGIN = (
+const _DIRECT_BACKEND_ORIGIN = (
   process.env.NEXT_PUBLIC_BACKEND_URL ||
   [
     ["https", "://"].join(""),
@@ -42,7 +42,8 @@ const DIRECT_BACKEND_ORIGIN = (
 
 function directApi(path: string): string {
   if (path.startsWith("http")) return path;
-  if (path.startsWith("/api/")) return `${DIRECT_BACKEND_ORIGIN}${path}`;
+  // IMPORTANT: In the browser, keep /api/* same-origin to avoid CORS (Next API proxies server-side).
+  if (path.startsWith("/api/")) return path;
   return path;
 }
 


### PR DESCRIPTION
- Browser fetches now keep /api/* same-origin\n- Next API routes proxy to backend server-side (avoids CORS)\n- Rename unused DIRECT_BACKEND_ORIGIN -> _DIRECT_BACKEND_ORIGIN