### PR TITLE
Add ownership domain adapter v0

### DIFF
--- a/docs/DOMAIN_MODEL_V0.md
+++ b/docs/DOMAIN_MODEL_V0.md
@@ -1,0 +1,235 @@
+# Domain Model v0
+
+This is an adapter-layer model for current Spotify Shopper ownership data.
+It documents a safer vocabulary without changing backend contracts or runtime
+behavior.
+
+## Goals
+
+- Keep canonical track identity separate from ownership state.
+- Keep ownership state separate from match evidence.
+- Make user corrections an explicit overlay, not a mutation of match evidence.
+- Describe current frontend semantics honestly, especially around `owned: false`.
+
+## Current Repo Inputs
+
+Current frontend rows use `PlaylistRow` fields:
+
+```ts
+type CurrentTrackOwnershipFields = Pick<
+  PlaylistRow,
+  | "owned"
+  | "ownedReason"
+  | "trackKeyPrimary"
+  | "trackKeyFallback"
+  | "trackKeyPrimaryType"
+> & {
+  ownedSource?: unknown;
+  trackKeyVersion?: unknown;
+};
+```
+
+API snake_case inputs currently map to these frontend fields:
+
+- `owned` -> `owned`
+- `owned_reason` -> `ownedReason`
+- `track_key_primary` -> `trackKeyPrimary`
+- `track_key_fallback` -> `trackKeyFallback`
+- `track_key_primary_type` -> `trackKeyPrimaryType`
+- `track_key_version` -> not retained on `PlaylistRow` today
+
+Important: `OwnershipState` below is derived from the current normalized
+frontend contract. Today, `owned: false` may include weaker semantics than a
+strongly proven not-owned state because API `null`, missing, or unrecognized
+ownership can be normalized to `false` before it reaches `PlaylistRow`.
+
+## Minimal Types
+
+```ts
+export type TrackKeyType = "isrc" | "norm";
+
+export type CanonicalTrackIdentity = {
+  primary: {
+    type: TrackKeyType;
+    value: string;
+    version: string;
+  };
+  fallback?: {
+    type: "norm";
+    value: string;
+    version: string;
+  };
+};
+
+export type OwnershipState = "owned" | "not_owned" | "unknown";
+
+export type MatchMethod =
+  | "isrc"
+  | "exact"
+  | "album"
+  | "fuzzy"
+  | "canonical"
+  | "guess"
+  | "none"
+  | "unknown";
+
+export type MatchConfidence = "high" | "medium" | "low" | "unknown";
+
+export type MatchEvidenceSource =
+  | "api"
+  | "rekordbox_rematch"
+  | "frontend_canonical_lookup"
+  | "user_correction"
+  | "unknown";
+
+export type MatchEvidence = {
+  method: MatchMethod;
+  confidence: MatchConfidence;
+  source: MatchEvidenceSource;
+  rawReason?: string | null;
+};
+
+export type CorrectionEvent = {
+  track: CanonicalTrackIdentity;
+  action: "set_owned" | "set_not_owned" | "clear_override";
+  previousOwnership: OwnershipState;
+  previousEvidence?: MatchEvidence;
+  createdAtISO: string;
+};
+
+export type EffectiveOwnership = {
+  state: OwnershipState;
+  identity: CanonicalTrackIdentity;
+  evidence: MatchEvidence;
+  correction?: CorrectionEvent;
+  source: MatchEvidenceSource;
+};
+```
+
+## Pure Adapter Spec
+
+These functions are pure and should have no storage, network, React, or backend
+side effects.
+
+```ts
+export function toCanonicalTrackIdentity(
+  track: CurrentTrackOwnershipFields,
+): CanonicalTrackIdentity | null;
+
+export function toOwnershipState(
+  owned: boolean | null | undefined,
+): OwnershipState;
+
+export function toMatchEvidence(input: {
+  ownedReason: string | null | undefined;
+  owned: boolean | null | undefined;
+  source?: MatchEvidenceSource;
+}): MatchEvidence;
+
+export function toEffectiveOwnership(input: {
+  track: CurrentTrackOwnershipFields;
+  correction?: CorrectionEvent;
+  source?: MatchEvidenceSource;
+}): EffectiveOwnership | null;
+
+export function createCorrectionEvent(input: {
+  track: CurrentTrackOwnershipFields;
+  action: CorrectionEvent["action"];
+  createdAtISO: string;
+}): CorrectionEvent | null;
+```
+
+## Mapping Rules
+
+### CanonicalTrackIdentity
+
+- If `trackKeyPrimary` is absent or empty, return `null`.
+- `trackKeyPrimary` maps to `primary.value`.
+- `trackKeyPrimaryType === "isrc"` maps to `primary.type = "isrc"`.
+- Any other current value maps to `primary.type = "norm"`.
+- `trackKeyVersion` maps to `primary.version` if it is a string.
+- Otherwise default `primary.version` to `"v1"`.
+- If `trackKeyFallback` is present, map it to `fallback.value`.
+- `fallback.type` is always `"norm"` in v0.
+- `fallback.version` uses the same version as `primary.version`.
+
+### OwnershipState
+
+- `owned === true` maps to `"owned"`.
+- `owned === false` maps to `"not_owned"` under the current frontend contract.
+- `owned == null` maps to `"unknown"`.
+
+Note: v0 does not claim that `"not_owned"` is a strong backend proof. It means
+the current normalized frontend row is not owned. This may include weaker states
+that were collapsed to `false` during normalization.
+
+### MatchEvidence
+
+- `ownedReason === "isrc"` maps to method `"isrc"`, confidence `"high"`.
+- `ownedReason === "exact"` maps to method `"exact"`, confidence `"high"`.
+- `ownedReason === "album"` maps to method `"album"`, confidence `"medium"`.
+- `ownedReason === "fuzzy"` maps to method `"fuzzy"`, confidence `"low"`.
+- Reason containing `"canonical"` maps to method `"canonical"`, confidence
+  `"unknown"`, preserving `rawReason`.
+- Reason containing `"guess"` maps to method `"guess"`, confidence `"low"`,
+  preserving `rawReason`.
+- Empty reason with `owned === false` maps to method `"none"`, confidence
+  `"unknown"`.
+- Empty reason with any other ownership maps to method `"unknown"`, confidence
+  `"unknown"`.
+- Unknown reason strings map to method `"unknown"`, confidence `"unknown"`,
+  preserving `rawReason`.
+- Missing `source` maps to `"unknown"`.
+
+### CorrectionEvent
+
+- If canonical identity cannot be produced, return `null`.
+- A correction records a user action against the canonical identity.
+- A correction must preserve previous ownership and previous evidence.
+- A correction must not rewrite `ownedReason`.
+- Persistence, precedence, and conflict handling are out of scope for v0.
+
+### EffectiveOwnership
+
+- If canonical identity cannot be produced, return `null`.
+- Without a correction, use adapter-derived ownership and evidence.
+- With `set_owned`, state becomes `"owned"` and source becomes
+  `"user_correction"`.
+- With `set_not_owned`, state becomes `"not_owned"` and source becomes
+  `"user_correction"`.
+- With `clear_override`, use adapter-derived ownership and evidence.
+- Evidence remains separate from the final effective state.
+
+## Explicit Unknowns
+
+- Whether backend `owned_reason` is a closed vocabulary.
+- Whether fuzzy evidence should ever count as final owned, maybe owned, or
+  unknown.
+- Backend confidence thresholds, if any.
+- Whether `track_key_version` can differ from `"v1"`.
+- Whether `ownedSource` is intended to be a durable frontend field.
+- How user corrections should persist.
+- How user corrections should resolve conflicts with future backend matches.
+- Whether API `owned: null` has distinct backend meaning, because the current
+  frontend normalization can collapse it to `false`.
+
+## Types/Docs Only First
+
+Safe first additions with no runtime behavior change:
+
+- This document.
+- A type-only module exporting the v0 domain types.
+- Unit test fixtures documenting expected pure adapter behavior, without
+  importing the adapter into UI selectors, table rendering, API normalization,
+  or snapshot matching.
+
+## Safest First Code Change
+
+Add `lib/domain/ownership.ts` with only v0 types and pure adapter helpers, plus
+focused tests. Do not wire it into runtime paths yet:
+
+- Do not change API schemas.
+- Do not change backend payloads.
+- Do not change `normalizeTrack`.
+- Do not change `categorizeTrack`.
+- Do not change owned badges, filtering, counts, or buy queue behavior.

--- a/lib/domain/ownership.ts
+++ b/lib/domain/ownership.ts
@@ -1,0 +1,230 @@
+import type { PlaylistRow } from "../types";
+
+export type TrackKeyType = "isrc" | "norm";
+
+export type CanonicalTrackIdentity = {
+  primary: {
+    type: TrackKeyType;
+    value: string;
+    version: string;
+  };
+  fallback?: {
+    type: "norm";
+    value: string;
+    version: string;
+  };
+};
+
+export type OwnershipState = "owned" | "not_owned" | "unknown";
+
+export type MatchMethod =
+  | "isrc"
+  | "exact"
+  | "album"
+  | "fuzzy"
+  | "canonical"
+  | "guess"
+  | "none"
+  | "unknown";
+
+export type MatchConfidence = "high" | "medium" | "low" | "unknown";
+
+export type MatchEvidenceSource =
+  | "api"
+  | "rekordbox_rematch"
+  | "frontend_canonical_lookup"
+  | "user_correction"
+  | "unknown";
+
+export type MatchEvidence = {
+  method: MatchMethod;
+  confidence: MatchConfidence;
+  source: MatchEvidenceSource;
+  rawReason?: string | null;
+};
+
+export type CorrectionEvent = {
+  track: CanonicalTrackIdentity;
+  action: "set_owned" | "set_not_owned" | "clear_override";
+  previousOwnership: OwnershipState;
+  previousEvidence?: MatchEvidence;
+  createdAtISO: string;
+};
+
+export type EffectiveOwnership = {
+  state: OwnershipState;
+  identity: CanonicalTrackIdentity;
+  evidence: MatchEvidence;
+  correction?: CorrectionEvent;
+  source: MatchEvidenceSource;
+};
+
+export type CurrentTrackOwnershipFields = Pick<
+  PlaylistRow,
+  | "owned"
+  | "ownedReason"
+  | "trackKeyPrimary"
+  | "trackKeyFallback"
+  | "trackKeyPrimaryType"
+> & {
+  ownedSource?: unknown;
+  trackKeyVersion?: unknown;
+};
+
+function asNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function isMatchEvidenceSource(value: unknown): value is MatchEvidenceSource {
+  return (
+    value === "api" ||
+    value === "rekordbox_rematch" ||
+    value === "frontend_canonical_lookup" ||
+    value === "user_correction" ||
+    value === "unknown"
+  );
+}
+
+function normalizeSource(value: unknown): MatchEvidenceSource {
+  return isMatchEvidenceSource(value) ? value : "unknown";
+}
+
+function classifyReason(reason: string | null): {
+  method: MatchMethod;
+  confidence: MatchConfidence;
+} {
+  if (reason === "isrc" || reason === "exact") {
+    return { method: reason, confidence: "high" };
+  }
+  if (reason === "album") {
+    return { method: "album", confidence: "medium" };
+  }
+  if (reason === "fuzzy") {
+    return { method: "fuzzy", confidence: "low" };
+  }
+  if (reason?.includes("canonical")) {
+    return { method: "canonical", confidence: "unknown" };
+  }
+  if (reason?.includes("guess")) {
+    return { method: "guess", confidence: "low" };
+  }
+  return { method: "unknown", confidence: "unknown" };
+}
+
+export function toCanonicalTrackIdentity(
+  track: CurrentTrackOwnershipFields,
+): CanonicalTrackIdentity | null {
+  const primaryValue = asNonEmptyString(track.trackKeyPrimary);
+  if (!primaryValue) return null;
+
+  const version = asNonEmptyString(track.trackKeyVersion) ?? "v1";
+  const identity: CanonicalTrackIdentity = {
+    primary: {
+      type: track.trackKeyPrimaryType === "isrc" ? "isrc" : "norm",
+      value: primaryValue,
+      version,
+    },
+  };
+
+  const fallbackValue = asNonEmptyString(track.trackKeyFallback);
+  if (fallbackValue) {
+    identity.fallback = {
+      type: "norm",
+      value: fallbackValue,
+      version,
+    };
+  }
+
+  return identity;
+}
+
+export function toOwnershipState(
+  owned: boolean | null | undefined,
+): OwnershipState {
+  if (owned === true) return "owned";
+  if (owned === false) return "not_owned";
+  return "unknown";
+}
+
+export function toMatchEvidence(input: {
+  ownedReason: string | null | undefined;
+  owned: boolean | null | undefined;
+  source?: MatchEvidenceSource;
+}): MatchEvidence {
+  const rawReason = asNonEmptyString(input.ownedReason);
+  const source = normalizeSource(input.source);
+
+  if (!rawReason && input.owned === false) {
+    return {
+      method: "none",
+      confidence: "unknown",
+      source,
+      rawReason: input.ownedReason ?? null,
+    };
+  }
+
+  const classified = classifyReason(rawReason);
+  return {
+    ...classified,
+    source,
+    rawReason: input.ownedReason ?? null,
+  };
+}
+
+export function toEffectiveOwnership(input: {
+  track: CurrentTrackOwnershipFields;
+  correction?: CorrectionEvent;
+  source?: MatchEvidenceSource;
+}): EffectiveOwnership | null {
+  const identity = toCanonicalTrackIdentity(input.track);
+  if (!identity) return null;
+
+  const source = normalizeSource(input.source ?? input.track.ownedSource);
+  const state = toOwnershipState(input.track.owned);
+  const evidence = toMatchEvidence({
+    owned: input.track.owned,
+    ownedReason: input.track.ownedReason,
+    source,
+  });
+
+  if (!input.correction || input.correction.action === "clear_override") {
+    return {
+      state,
+      identity,
+      evidence,
+      correction: input.correction,
+      source,
+    };
+  }
+
+  return {
+    state: input.correction.action === "set_owned" ? "owned" : "not_owned",
+    identity,
+    evidence: input.correction.previousEvidence ?? evidence,
+    correction: input.correction,
+    source: "user_correction",
+  };
+}
+
+export function createCorrectionEvent(input: {
+  track: CurrentTrackOwnershipFields;
+  action: CorrectionEvent["action"];
+  createdAtISO: string;
+}): CorrectionEvent | null {
+  const identity = toCanonicalTrackIdentity(input.track);
+  if (!identity) return null;
+
+  return {
+    track: identity,
+    action: input.action,
+    previousOwnership: toOwnershipState(input.track.owned),
+    previousEvidence: toMatchEvidence({
+      owned: input.track.owned,
+      ownedReason: input.track.ownedReason,
+      source: normalizeSource(input.track.ownedSource),
+    }),
+    createdAtISO: input.createdAtISO,
+  };
+}

--- a/tests/ownership-adapters.test.ts
+++ b/tests/ownership-adapters.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, test } from "vitest";
+import {
+  createCorrectionEvent,
+  toCanonicalTrackIdentity,
+  toEffectiveOwnership,
+  toMatchEvidence,
+  toOwnershipState,
+  type CurrentTrackOwnershipFields,
+} from "../lib/domain/ownership";
+
+const baseTrack: CurrentTrackOwnershipFields = {
+  owned: true,
+  ownedReason: "isrc",
+  trackKeyPrimary: "isrc:JP1234567890",
+  trackKeyFallback: "norm:track a|artist a|album a",
+  trackKeyPrimaryType: "isrc",
+};
+
+describe("ownership domain adapters", () => {
+  test("maps canonical identity from current track fields", () => {
+    expect(
+      toCanonicalTrackIdentity({
+        ...baseTrack,
+        trackKeyVersion: "v2",
+      }),
+    ).toEqual({
+      primary: {
+        type: "isrc",
+        value: "isrc:JP1234567890",
+        version: "v2",
+      },
+      fallback: {
+        type: "norm",
+        value: "norm:track a|artist a|album a",
+        version: "v2",
+      },
+    });
+  });
+
+  test("returns null when primary identity is missing", () => {
+    expect(
+      toCanonicalTrackIdentity({
+        ...baseTrack,
+        trackKeyPrimary: undefined,
+      }),
+    ).toBeNull();
+    expect(
+      toCanonicalTrackIdentity({
+        ...baseTrack,
+        trackKeyPrimary: "   ",
+      }),
+    ).toBeNull();
+  });
+
+  test("defaults canonical identity type and version conservatively", () => {
+    expect(
+      toCanonicalTrackIdentity({
+        ...baseTrack,
+        trackKeyPrimary: "norm:track a|artist a|album a",
+        trackKeyFallback: undefined,
+        trackKeyPrimaryType: undefined,
+      }),
+    ).toEqual({
+      primary: {
+        type: "norm",
+        value: "norm:track a|artist a|album a",
+        version: "v1",
+      },
+    });
+  });
+
+  test("maps ownership from current normalized frontend booleans", () => {
+    expect(toOwnershipState(true)).toBe("owned");
+    expect(toOwnershipState(false)).toBe("not_owned");
+    expect(toOwnershipState(null)).toBe("unknown");
+    expect(toOwnershipState(undefined)).toBe("unknown");
+  });
+
+  test("maps known match reasons to confidence levels", () => {
+    expect(
+      toMatchEvidence({
+        owned: true,
+        ownedReason: "exact",
+        source: "api",
+      }),
+    ).toEqual({
+      method: "exact",
+      confidence: "high",
+      source: "api",
+      rawReason: "exact",
+    });
+    expect(
+      toMatchEvidence({
+        owned: true,
+        ownedReason: "album",
+        source: "rekordbox_rematch",
+      }),
+    ).toEqual({
+      method: "album",
+      confidence: "medium",
+      source: "rekordbox_rematch",
+      rawReason: "album",
+    });
+    expect(
+      toMatchEvidence({
+        owned: true,
+        ownedReason: "fuzzy",
+      }),
+    ).toEqual({
+      method: "fuzzy",
+      confidence: "low",
+      source: "unknown",
+      rawReason: "fuzzy",
+    });
+  });
+
+  test("preserves raw reasons for canonical, guess, and unknown evidence", () => {
+    expect(
+      toMatchEvidence({
+        owned: true,
+        ownedReason: "isrc (canonical match)",
+        source: "frontend_canonical_lookup",
+      }),
+    ).toEqual({
+      method: "canonical",
+      confidence: "unknown",
+      source: "frontend_canonical_lookup",
+      rawReason: "isrc (canonical match)",
+    });
+    expect(
+      toMatchEvidence({
+        owned: true,
+        ownedReason: "guess",
+      }),
+    ).toEqual({
+      method: "guess",
+      confidence: "low",
+      source: "unknown",
+      rawReason: "guess",
+    });
+    expect(
+      toMatchEvidence({
+        owned: true,
+        ownedReason: "future-backend-reason",
+      }),
+    ).toEqual({
+      method: "unknown",
+      confidence: "unknown",
+      source: "unknown",
+      rawReason: "future-backend-reason",
+    });
+  });
+
+  test("maps absent evidence on not-owned rows to none", () => {
+    expect(
+      toMatchEvidence({
+        owned: false,
+        ownedReason: null,
+        source: "api",
+      }),
+    ).toEqual({
+      method: "none",
+      confidence: "unknown",
+      source: "api",
+      rawReason: null,
+    });
+  });
+
+  test("builds effective ownership without applying corrections", () => {
+    expect(
+      toEffectiveOwnership({
+        track: {
+          ...baseTrack,
+          ownedSource: "rekordbox_rematch",
+        },
+      }),
+    ).toEqual({
+      state: "owned",
+      identity: {
+        primary: {
+          type: "isrc",
+          value: "isrc:JP1234567890",
+          version: "v1",
+        },
+        fallback: {
+          type: "norm",
+          value: "norm:track a|artist a|album a",
+          version: "v1",
+        },
+      },
+      evidence: {
+        method: "isrc",
+        confidence: "high",
+        source: "rekordbox_rematch",
+        rawReason: "isrc",
+      },
+      source: "rekordbox_rematch",
+    });
+  });
+
+  test("applies correction as an overlay without rewriting previous evidence", () => {
+    const correction = createCorrectionEvent({
+      track: baseTrack,
+      action: "set_not_owned",
+      createdAtISO: "2026-05-26T00:00:00.000Z",
+    });
+
+    expect(correction).toEqual({
+      track: {
+        primary: {
+          type: "isrc",
+          value: "isrc:JP1234567890",
+          version: "v1",
+        },
+        fallback: {
+          type: "norm",
+          value: "norm:track a|artist a|album a",
+          version: "v1",
+        },
+      },
+      action: "set_not_owned",
+      previousOwnership: "owned",
+      previousEvidence: {
+        method: "isrc",
+        confidence: "high",
+        source: "unknown",
+        rawReason: "isrc",
+      },
+      createdAtISO: "2026-05-26T00:00:00.000Z",
+    });
+
+    expect(
+      toEffectiveOwnership({
+        track: baseTrack,
+        correction: correction ?? undefined,
+        source: "api",
+      }),
+    ).toEqual({
+      state: "not_owned",
+      identity: {
+        primary: {
+          type: "isrc",
+          value: "isrc:JP1234567890",
+          version: "v1",
+        },
+        fallback: {
+          type: "norm",
+          value: "norm:track a|artist a|album a",
+          version: "v1",
+        },
+      },
+      evidence: {
+        method: "isrc",
+        confidence: "high",
+        source: "unknown",
+        rawReason: "isrc",
+      },
+      correction,
+      source: "user_correction",
+    });
+  });
+});


### PR DESCRIPTION
Adds the first docs-first / adapter-first ownership domain layer without changing runtime behavior.

Included:
- docs/DOMAIN_MODEL_V0.md
- lib/domain/ownership.ts
- tests/ownership-adapters.test.ts

What this does:
- separates canonical track identity from ownership state
- separates ownership state from match evidence
- introduces correction/effective ownership vocabulary
- keeps the new adapter unused in runtime paths for now

Validation:
- pnpm test -- tests/ownership-adapters.test.ts
- pnpm typecheck
- pnpm lint

Notes:
- no backend contract changes
- no runtime wiring yet
- existing UI/runtime behavior remains unchanged