### PR TITLE
Improve results table hierarchy for purchase decisions

### DIFF
--- a/app/components/BuyQueuePanel.tsx
+++ b/app/components/BuyQueuePanel.tsx
@@ -9,25 +9,25 @@ type BuyQueuePanelProps = {
 
 export default function BuyQueuePanel({ items, onRemove }: BuyQueuePanelProps) {
   return (
-    <details className="rounded-lg border border-slate-800 bg-slate-900/40 px-4 py-3 text-xs text-slate-400">
-      <summary className="cursor-pointer list-none font-medium text-slate-300">
+    <details className="rounded-lg border border-slate-700/80 bg-slate-900/50 px-4 py-3 text-xs text-slate-400">
+      <summary className="cursor-pointer list-none font-semibold text-slate-200">
         あとで買う ({items.length})
       </summary>
 
-      <div className="mt-3 space-y-2">
+      <div className="mt-3 space-y-2.5">
         {items.length === 0 ? (
           <p>解析後に、持っていない曲をここに追加できます。</p>
         ) : (
           items.map((item) => (
             <div
               key={item.id}
-              className="flex flex-col gap-2 rounded-md border border-slate-800 bg-slate-950/50 p-3 sm:flex-row sm:items-center sm:justify-between"
+              className="flex flex-col gap-3 rounded-md border border-slate-800 bg-slate-950/50 p-3.5 sm:flex-row sm:items-center sm:justify-between"
             >
               <div className="min-w-0">
-                <div className="truncate text-sm font-medium text-slate-100">
+                <div className="truncate text-sm font-semibold text-slate-100">
                   {item.title}
                 </div>
-                <div className="truncate text-slate-400">
+                <div className="truncate text-slate-300">
                   {item.artist}
                   {item.album ? ` · ${item.album}` : ""}
                 </div>
@@ -36,19 +36,19 @@ export default function BuyQueuePanel({ items, onRemove }: BuyQueuePanelProps) {
                   {item.isrc ? ` · ${item.isrc}` : ""}
                 </div>
               </div>
-              <div className="flex shrink-0 flex-wrap gap-2">
+              <div className="flex shrink-0 flex-wrap gap-1.5">
                 <a
                   href={item.buyUrl}
                   target="_blank"
                   rel="noreferrer"
-                  className="rounded-md border border-emerald-500/60 bg-emerald-500/10 px-2 py-1 text-emerald-200 hover:bg-emerald-500/20"
+                  className="rounded-md border border-emerald-400/40 bg-emerald-500/15 px-2.5 py-1.5 font-medium text-emerald-100 hover:bg-emerald-500/25"
                 >
                   ストアで見る
                 </a>
                 <button
                   type="button"
                   onClick={() => onRemove(item.id)}
-                  className="rounded-md border border-slate-700 px-2 py-1 text-slate-300 hover:text-white"
+                  className="rounded-md border border-slate-700/70 bg-transparent px-2.5 py-1.5 text-slate-400 hover:border-slate-600 hover:bg-slate-800/50 hover:text-slate-200"
                 >
                   削除
                 </button>

--- a/app/components/ResultsTable.tsx
+++ b/app/components/ResultsTable.tsx
@@ -96,7 +96,7 @@ function StoreLinksInline({ track }: { track: PlaylistRow }) {
   const mainLabel = primary?.name ?? "ストア";
 
   return (
-    <div className="flex flex-wrap items-center gap-2">
+    <div className="flex flex-wrap items-center gap-1.5">
       <a
         href={primary?.url || "#"}
         target="_blank"
@@ -105,8 +105,10 @@ function StoreLinksInline({ track }: { track: PlaylistRow }) {
         onClick={(e) => {
           if (!primary) e.preventDefault();
         }}
-        className={`inline-flex items-center rounded-md bg-white/10 px-2 py-1 text-[11px] text-white ${
-          primary ? "hover:bg-white/15" : "opacity-50 cursor-not-allowed"
+        className={`inline-flex items-center rounded-md border border-emerald-400/30 bg-emerald-500/15 px-2.5 py-1.5 text-[11px] font-medium text-emerald-100 ${
+          primary
+            ? "hover:border-emerald-300/50 hover:bg-emerald-500/25"
+            : "opacity-50 cursor-not-allowed"
         }`}
         title={primary ? "Open store" : "No store link"}
       >
@@ -121,8 +123,10 @@ function StoreLinksInline({ track }: { track: PlaylistRow }) {
         onClick={(e) => {
           if (!yt) e.preventDefault();
         }}
-        className={`inline-flex items-center rounded-md bg-white/10 px-2 py-1 text-[11px] text-white ${
-          yt ? "hover:bg-white/15" : "opacity-50 cursor-not-allowed"
+        className={`inline-flex items-center rounded-md border border-white/10 bg-white/[0.03] px-2 py-1 text-[11px] text-white/55 ${
+          yt
+            ? "hover:bg-white/10 hover:text-white/80"
+            : "opacity-50 cursor-not-allowed"
         }`}
         title={yt ? "Open YouTube Music Topic search" : "Missing title/artist"}
       >
@@ -135,7 +139,7 @@ function StoreLinksInline({ track }: { track: PlaylistRow }) {
           href={s.url}
           target="_blank"
           rel="noreferrer"
-          className="inline-flex items-center gap-1 rounded-md bg-white/10 px-2 py-1 text-[11px] text-white hover:bg-white/15"
+          className="inline-flex items-center gap-1 rounded-md border border-white/10 bg-white/[0.03] px-2 py-1 text-[11px] text-white/55 hover:bg-white/10 hover:text-white/80"
         >
           {s.name}
         </a>
@@ -172,16 +176,16 @@ export default function ResultsTable({
         )}
       </div>
 
-      <div className="hidden md:block rounded-2xl border border-white/10 overflow-x-auto">
+      <div className="hidden md:block rounded-2xl border border-white/10 overflow-x-auto bg-white/[0.02]">
         <table className="min-w-[980px] w-full text-xs">
-          <thead className="bg-white/5 text-white/70">
+          <thead className="bg-white/[0.04] text-white/55">
             <tr>
-              <th className="px-3 py-2 text-left">Title</th>
-              <th className="px-3 py-2 text-left">Artist</th>
-              <th className="px-3 py-2 text-left">Album</th>
-              <th className="px-3 py-2 text-left">ISRC</th>
-              <th className="px-3 py-2 text-left">ストア</th>
-              <th className="px-3 py-2 text-left">あとで買う</th>
+              <th className="px-4 py-2.5 text-left font-medium">Title</th>
+              <th className="px-4 py-2.5 text-left font-medium">Artist</th>
+              <th className="px-4 py-2.5 text-left font-medium">Album</th>
+              <th className="px-4 py-2.5 text-left font-medium">ISRC</th>
+              <th className="px-4 py-2.5 text-left font-medium">ストア</th>
+              <th className="px-4 py-2.5 text-left font-medium">あとで買う</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-white/10">
@@ -192,15 +196,24 @@ export default function ResultsTable({
                 queuedTrackIds?.has(getBuyQueueItemId(t)) ?? false;
 
               return (
-                <tr key={`${t?.isrc ?? ""}-${i}`} className="hover:bg-white/5">
-                  <td className="px-3 py-2 text-white">{t?.title ?? ""}</td>
-                  <td className="px-3 py-2 text-white/80">{t?.artist ?? ""}</td>
-                  <td className="px-3 py-2 text-white/60">{t?.album ?? ""}</td>
-                  <td className="px-3 py-2 text-white/40">{t?.isrc ?? ""}</td>
-                  <td className="px-3 py-2">
+                <tr
+                  key={`${t?.isrc ?? ""}-${i}`}
+                  className="hover:bg-white/[0.04]"
+                >
+                  <td className="px-4 py-3 text-sm font-medium text-white">
+                    {t?.title ?? ""}
+                  </td>
+                  <td className="px-4 py-3 text-sm text-white/85">
+                    {t?.artist ?? ""}
+                  </td>
+                  <td className="px-4 py-3 text-white/45">{t?.album ?? ""}</td>
+                  <td className="px-4 py-3 font-mono text-[11px] text-white/30">
+                    {t?.isrc ?? ""}
+                  </td>
+                  <td className="px-4 py-3">
                     <StoreLinksInline track={t} />
                   </td>
-                  <td className="px-3 py-2">
+                  <td className="px-4 py-3">
                     {t.owned === true ? (
                       <span className="text-[11px] text-white/40">Owned</span>
                     ) : (
@@ -210,7 +223,7 @@ export default function ResultsTable({
                         onClick={() => {
                           if (primary) onAddToBuyQueue?.(t, primary);
                         }}
-                        className="rounded-md border border-white/10 bg-white/5 px-2 py-1 text-[11px] text-white/80 hover:bg-white/10 disabled:opacity-40"
+                        className="rounded-md border border-white/15 bg-white/10 px-2.5 py-1.5 text-[11px] font-medium text-white/85 hover:bg-white/15 disabled:opacity-40"
                       >
                         {isQueued ? "追加済み" : "あとで買うへ追加"}
                       </button>
@@ -243,35 +256,35 @@ function TrackCard({
   const canQueue = track.owned !== true && Boolean(primary);
 
   return (
-    <div className="rounded-xl border border-white/10 bg-white/5 p-3">
+    <div className="rounded-xl border border-white/10 bg-white/5 p-4">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <div className="text-sm font-medium text-white truncate">
+          <div className="text-base font-semibold text-white truncate">
             {track?.title ?? ""}
           </div>
-          <div className="text-xs text-white/70 truncate">
+          <div className="text-sm text-white/80 truncate">
             {track?.artist ?? ""}
           </div>
-          <div className="text-xs text-white/50 truncate">
+          <div className="text-xs text-white/45 truncate">
             {track?.album ?? ""}
           </div>
         </div>
-        <div className="shrink-0 text-[11px] text-white/40">
+        <div className="shrink-0 font-mono text-[11px] text-white/30">
           {track?.isrc ?? ""}
         </div>
       </div>
-      <div className="mt-2">
+      <div className="mt-3">
         <StoreLinksInline track={track} />
       </div>
       {track.owned !== true ? (
-        <div className="mt-2">
+        <div className="mt-3">
           <button
             type="button"
             disabled={!canQueue || isQueued}
             onClick={() => {
               if (primary) onAddToBuyQueue?.(track, primary);
             }}
-            className="rounded-md border border-white/10 bg-white/5 px-2 py-1 text-[11px] text-white/80 hover:bg-white/10 disabled:opacity-40"
+            className="rounded-md border border-white/15 bg-white/10 px-2.5 py-1.5 text-[11px] font-medium text-white/85 hover:bg-white/15 disabled:opacity-40"
           >
             {isQueued ? "追加済み" : "あとで買うへ追加"}
           </button>


### PR DESCRIPTION
Improves the results table and buy-later panel visual hierarchy for purchase decisions.

Included:
- app/components/ResultsTable.tsx
- app/components/BuyQueuePanel.tsx

What this does:
- makes title and artist easier to scan
- makes main store and buy-later actions more prominent
- quiets secondary metadata and actions
- keeps wording, links, and behavior unchanged

Validation:
- pnpm typecheck
- pnpm lint