### PR TITLE
Refine UI copy labels

### DIFF
--- a/app/components/BuyQueuePanel.tsx
+++ b/app/components/BuyQueuePanel.tsx
@@ -11,12 +11,12 @@ export default function BuyQueuePanel({ items, onRemove }: BuyQueuePanelProps) {
   return (
     <details className="rounded-lg border border-slate-800 bg-slate-900/40 px-4 py-3 text-xs text-slate-400">
       <summary className="cursor-pointer list-none font-medium text-slate-300">
-        あとで買う ({items.length})
+        Buy Later ({items.length})
       </summary>
 
       <div className="mt-3 space-y-2">
         {items.length === 0 ? (
-          <p>解析後に、持っていない曲をここに追加できます。</p>
+          <p>Save not-owned tracks here after analysis.</p>
         ) : (
           items.map((item) => (
             <div
@@ -43,14 +43,14 @@ export default function BuyQueuePanel({ items, onRemove }: BuyQueuePanelProps) {
                   rel="noreferrer"
                   className="rounded-md border border-emerald-500/60 bg-emerald-500/10 px-2 py-1 text-emerald-200 hover:bg-emerald-500/20"
                 >
-                  ストアで見る
+                  Open store
                 </a>
                 <button
                   type="button"
                   onClick={() => onRemove(item.id)}
                   className="rounded-md border border-slate-700 px-2 py-1 text-slate-300 hover:text-white"
                 >
-                  削除
+                  Remove
                 </button>
               </div>
             </div>

--- a/app/components/ResultsTable.tsx
+++ b/app/components/ResultsTable.tsx
@@ -84,7 +84,7 @@ function getPrimaryBuyLink(
   const fallback = beatportSearchUrl(track) || bandcampSearchUrl(track);
   const url = primaryUrl || fallback;
   if (!url) return null;
-  return { name: recommended?.name ?? (primaryUrl ? "ストア" : "検索"), url };
+  return { name: recommended?.name ?? (primaryUrl ? "Store" : "Search"), url };
 }
 
 function displayMetric(track: PlaylistRow, keys: string[]): string {
@@ -107,7 +107,7 @@ function StoreLinksInline({ track }: { track: PlaylistRow }) {
   const primary = getPrimaryBuyLink(track);
   const yt = youtubeTopicUrl(track);
 
-  const mainLabel = primary?.name ?? "ストア";
+  const mainLabel = primary?.name ?? "Store";
 
   return (
     <div className="flex flex-wrap items-center gap-2">
@@ -202,8 +202,8 @@ export default function ResultsTable({
               <th scope="col">Owned</th>
               <th scope="col">BPM</th>
               <th scope="col">Key</th>
-              <th scope="col">ストア</th>
-              <th scope="col">あとで買う</th>
+              <th scope="col">Store</th>
+              <th scope="col">Save</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-white/10">
@@ -260,7 +260,7 @@ export default function ResultsTable({
                         }}
                         className="rounded-md border border-white/10 bg-white/5 px-2 py-1 text-[11px] text-white/80 hover:bg-white/10 disabled:opacity-40"
                       >
-                        {isQueued ? "追加済み" : "あとで買うへ追加"}
+                        {isQueued ? "Saved" : "Save"}
                       </button>
                     )}
                   </td>
@@ -321,7 +321,7 @@ function TrackCard({
             }}
             className="rounded-md border border-white/10 bg-white/5 px-2 py-1 text-[11px] text-white/80 hover:bg-white/10 disabled:opacity-40"
           >
-            {isQueued ? "追加済み" : "あとで買うへ追加"}
+            {isQueued ? "Saved" : "Save"}
           </button>
         </div>
       ) : null}


### PR DESCRIPTION
Refines visible UI labels to simple English while preserving behavior and layout.

Scope:
- app/components/ResultsTable.tsx
- app/components/BuyQueuePanel.tsx

Changes:
- Store / Search
- Save / Saved
- Buy Later
- Open store
- Remove

Validation:
- pnpm typecheck
- pnpm lint