### PR TITLE
Improve MVP landing and README copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,117 @@
-> NOTE: Apple Music support is currently disabled (backend Playwright removed). Re-enable will require restoring Apple scraping strategy.
+# Playlist Shopper
 
-Spotify Shopper Web — Next.js frontend.
+Find the tracks in your Spotify playlists that are missing from your Rekordbox library.
 
-## Getting Started
+Playlist Shopper is a focused DJ purchase-decision workflow. Upload a Rekordbox XML export, paste a Spotify playlist URL, and review which tracks you already own and which tracks you still need to buy.
 
-First, run the development server:
+## What It Does
+
+- Compares a Spotify playlist against a Rekordbox XML library export.
+- Splits results into `To buy` and `Owned`.
+- Opens available Beatport or Bandcamp links for purchase research.
+- Saves purchase candidates to `Buy Later` in the browser.
+- Keeps the workflow local-first in the frontend, with saved analysis summaries capped in local storage.
+
+## Who This Is For
+
+- DJs preparing sets.
+- DJs converting playlists into purchase lists.
+- DJs checking what is already in their Rekordbox library.
+
+## Basic Workflow
+
+1. Export Rekordbox XML.
+2. Upload the XML file.
+3. Paste a Spotify playlist URL.
+4. Analyze.
+5. Review `To buy` and `Owned`.
+6. Open Beatport or Bandcamp, or save tracks to `Buy Later`.
+
+## Current MVP Scope
+
+- Spotify playlist input.
+- Rekordbox XML upload.
+- Track ownership matching using the existing frontend/backend ownership logic.
+- Results table with `All`, `To buy`, and `Owned` filters.
+- Search and basic sorting by title, artist, or album.
+- CSV export for displayed results.
+- Browser-local saved results and `Buy Later` queue.
+
+## Known Limitations
+
+- Matching depends on playlist metadata and the exported Rekordbox XML.
+- Large XML files are limited to 50 MB in the frontend.
+- Saved results use browser local storage and may be cleared by the browser.
+- Purchase links are best-effort search or store links when available.
+- Only Spotify playlist URLs are supported in the current sharing flow.
+
+## Not Included Yet
+
+- Beatport affiliate links.
+- Apple Music.
+- Discogs.
+- BPM/Key.
+- Advanced library management.
+
+## Local Development
+
+Install dependencies:
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+pnpm install
 ```
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+Run the development server:
 
-This project uses optimized web fonts via Next.js.
+```bash
+pnpm dev
+```
 
-## Design Decisions
+Run validation:
 
-- Analyzer stores only core domain + progress; localStorage persists slim summaries with a ~300KB cap, exposing warnings via `storageWarning` and reset via `clearLocalData`.
-- URL utils centralized in `lib/utils/playlistUrl.ts` (`detectSourceFromUrl`, `sanitizeUrl`).
-- CSV injection mitigation: `lib/utils/csvSanitize.ts` prefixes cells starting with = + - @ with `'`.
+```bash
+pnpm test
+pnpm exec tsc --noEmit --incremental false
+pnpm lint
+pnpm build
+git diff --check
+```
 
-See `docs/DISTRIBUTION.md` for packaging with `git archive`.
+Other useful commands:
+
+```bash
+pnpm test:watch
+pnpm start
+pnpm api:sync
+```
+
+## Environment Variables
+
+See `.env.example` and `docs/env-contract.md`.
+
+- `NEXT_PUBLIC_API_BASE_URL`: public backend API base URL.
+
+The proxy also recognizes `BACKEND_URL`, `NEXT_PUBLIC_BACKEND_URL`, and `API_BASE_URL`; `BACKEND_URL` is the recommended server-side name when available.
+
+## Production Smoke Test Checklist
+
+After deployment:
+
+1. Open the production URL.
+2. Upload a valid Rekordbox XML export.
+3. Paste a Spotify playlist URL.
+4. Run analysis and confirm progress completes.
+5. Confirm results show `To buy` and `Owned` counts.
+6. Filter between `All`, `To buy`, and `Owned`.
+7. Open a Beatport or Bandcamp link when present.
+8. Add a track to `Buy Later`, then remove it.
+9. Export CSV for the displayed results.
+10. Refresh the page and confirm saved local results restore as expected.
+
+## Notes
+
+- Analyzer state stores only core domain data and progress.
+- Local storage persists slim summaries with a size cap and exposes reset through `Clear saved data`.
+- URL utilities live in `lib/utils/playlistUrl.ts`.
+- CSV injection mitigation lives in `lib/utils/csvSanitize.ts`.
+- See `docs/DISTRIBUTION.md` for packaging with `git archive`.

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -332,6 +332,30 @@ function PageInner() {
       <div className="mx-auto max-w-[1024px] px-4 py-12 sm:px-6 lg:py-14">
         <div className="space-y-12">
           <section>
+            <header className="mb-8 max-w-3xl space-y-4">
+              <p className="text-xs font-medium uppercase tracking-[0.18em] text-slate-500">
+                Playlist Shopper
+              </p>
+              <div className="space-y-3">
+                <h1 className="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+                  Find tracks missing from your Rekordbox library.
+                </h1>
+                <p className="max-w-2xl text-sm leading-6 text-slate-400 sm:text-base">
+                  Paste a Spotify playlist, upload your Rekordbox XML, and see
+                  what you still need to buy.
+                </p>
+              </div>
+              <div className="space-y-2 text-sm text-slate-500">
+                <div className="font-medium text-slate-400">
+                  Who this is for
+                </div>
+                <ul className="grid gap-1 sm:grid-cols-3">
+                  <li>DJs preparing sets</li>
+                  <li>DJs converting playlists into purchase lists</li>
+                  <li>DJs checking what is already in Rekordbox</li>
+                </ul>
+              </div>
+            </header>
             {analyzer.isProcessing && (
               <div className="mb-3 rounded-md border border-emerald-400/20 bg-emerald-400/5 px-3 py-2 text-[11px] text-emerald-100/80">
                 {analyzer.phaseLabel || "Processing…"}


### PR DESCRIPTION
Updates README and first-screen copy to position Playlist Shopper as a DJ purchase-decision workflow.

Changes:
- Clarify Playlist Shopper as a DJ purchase-decision workflow
- Add concise product one-liner
- Document MVP workflow
- Add current scope, limitations, and smoke test checklist
- Improve first-screen copy

Validation:
- pnpm test
- pnpm exec tsc --noEmit --incremental false
- pnpm lint
- pnpm build
- git diff --check~