### PR TITLE
Normalize frontend API errors

### DIFF
--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -1,4 +1,5 @@
 import type { ZodTypeAny } from "zod";
+import { normalizeApiError } from "./errors";
 
 export class SchemaMismatch extends Error {
   issues: unknown;
@@ -119,16 +120,20 @@ export async function fetchJson<T>(
   const url = resolveApiUrl(path);
   const res = await fetchWithRetry(url, init);
   const text = await res.text();
-  const raw = text ? (JSON.parse(text) as unknown) : {};
+  let raw: unknown = {};
+  try {
+    raw = text ? (JSON.parse(text) as unknown) : {};
+  } catch {
+    raw = text;
+  }
   if (!res.ok) {
-    throw { status: res.status, data: raw };
+    throw normalizeApiError({ status: res.status, data: raw });
   }
   if (!schema) return raw as T;
   const parsed = schema.safeParse(raw);
   if (!parsed.success) {
-    throw new SchemaMismatch(
-      "API response schema mismatch",
-      parsed.error.issues,
+    throw normalizeApiError(
+      new SchemaMismatch("API response schema mismatch", parsed.error.issues),
     );
   }
   return parsed.data as T;

--- a/lib/api/errors.ts
+++ b/lib/api/errors.ts
@@ -1,0 +1,201 @@
+export type NormalizedApiError = {
+  message: string;
+  status?: number;
+  code?: string;
+  requestId?: string;
+  detail?: unknown;
+  retryable?: boolean;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function pickString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    const s = asString(value);
+    if (s) return s;
+  }
+  return undefined;
+}
+
+function getDetail(data: unknown): unknown {
+  if (!isRecord(data)) return undefined;
+  return data.detail ?? data.error ?? data.message;
+}
+
+function getNestedData(error: unknown): unknown {
+  if (!isRecord(error)) return undefined;
+  return error.data ?? error.response ?? error.body;
+}
+
+function hasIssues(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    Array.isArray(value.issues) &&
+    (value.name === "ZodError" || value.name === "SchemaMismatch")
+  );
+}
+
+function isAbortLike(error: unknown, rawMessage?: string): boolean {
+  if (!isRecord(error)) return false;
+  return (
+    error.name === "AbortError" ||
+    error.code === "ABORT_ERR" ||
+    /abort|timeout|timed out/i.test(rawMessage ?? "")
+  );
+}
+
+function isNetworkLike(message?: string): boolean {
+  if (!message) return false;
+  return /failed to fetch|networkerror|network error|load failed|fetch failed/i.test(
+    message,
+  );
+}
+
+function isRetryable(status?: number, code?: string, rawMessage?: string) {
+  if (status && (status === 429 || status >= 500)) return true;
+  if (code && /timeout|network|unavailable|rate/i.test(code)) return true;
+  return (
+    isNetworkLike(rawMessage) || /timeout|timed out/i.test(rawMessage ?? "")
+  );
+}
+
+function userMessage(input: {
+  status?: number;
+  code?: string;
+  rawMessage?: string;
+  detail?: unknown;
+  abortLike?: boolean;
+  schemaLike?: boolean;
+}) {
+  const raw = [
+    input.code,
+    input.rawMessage,
+    isRecord(input.detail)
+      ? pickString(input.detail.error, input.detail.message, input.detail.code)
+      : asString(input.detail),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  if (input.abortLike || /timeout|timed out|aborted/.test(raw)) {
+    return "Analysis took too long. Please try again.";
+  }
+
+  if (isNetworkLike(input.rawMessage)) {
+    return "Could not reach the analysis server. Please try again.";
+  }
+
+  if (
+    /invalid.*playlist|playlist_invalid|url host is not allowed|spotify playlist url|invalid url|url parameter/.test(
+      raw,
+    )
+  ) {
+    return "Enter a valid Spotify playlist URL.";
+  }
+
+  if (/xml|rekordbox|match_snapshot|matching/.test(raw)) {
+    return "Could not analyze the Rekordbox XML. Please check the file and try again.";
+  }
+
+  if (
+    input.status &&
+    (input.status === 429 || input.status === 502 || input.status === 503)
+  ) {
+    return "Could not reach the analysis server. Please try again.";
+  }
+
+  if (input.status && input.status >= 500) {
+    return "Could not reach the analysis server. Please try again.";
+  }
+
+  if (input.schemaLike) {
+    return "Something went wrong. Please try again.";
+  }
+
+  return "Something went wrong. Please try again.";
+}
+
+export function normalizeApiError(error: unknown): NormalizedApiError {
+  const normalizedMessage = isRecord(error)
+    ? asString(error.message)
+    : undefined;
+  if (isRecord(error) && normalizedMessage && error.retryable !== undefined) {
+    return {
+      message: normalizedMessage,
+      status: asNumber(error.status),
+      code: asString(error.code),
+      requestId: pickString(error.requestId, error.request_id),
+      detail: error.detail,
+      retryable: Boolean(error.retryable),
+    };
+  }
+
+  const data = getNestedData(error);
+  const dataDetail = getDetail(data);
+  const detail =
+    dataDetail ?? (hasIssues(error) && isRecord(error) ? error.issues : data);
+
+  const status = isRecord(error)
+    ? (asNumber(error.status) ?? asNumber(error.statusCode))
+    : undefined;
+  const code = isRecord(error)
+    ? pickString(
+        error.code,
+        error.error_code,
+        isRecord(data) ? data.code : undefined,
+        isRecord(data) ? data.error : undefined,
+        isRecord(dataDetail) ? dataDetail.code : undefined,
+        isRecord(dataDetail) ? dataDetail.error_code : undefined,
+      )
+    : undefined;
+  const requestId = isRecord(error)
+    ? pickString(
+        error.requestId,
+        error.request_id,
+        isRecord(data) ? data.requestId : undefined,
+        isRecord(data) ? data.request_id : undefined,
+        isRecord(dataDetail) ? dataDetail.requestId : undefined,
+        isRecord(dataDetail) ? dataDetail.request_id : undefined,
+      )
+    : undefined;
+
+  const rawMessage = pickString(
+    isRecord(error) ? error.message : undefined,
+    isRecord(data) ? data.message : undefined,
+    isRecord(data) ? data.error : undefined,
+    isRecord(dataDetail) ? dataDetail.message : undefined,
+    isRecord(dataDetail) ? dataDetail.error : undefined,
+    asString(error),
+  );
+  const schemaLike = hasIssues(error);
+  const abortLike = isAbortLike(error, rawMessage);
+
+  return {
+    message: userMessage({
+      status,
+      code,
+      rawMessage,
+      detail,
+      abortLike,
+      schemaLike,
+    }),
+    status,
+    code,
+    requestId,
+    detail,
+    retryable: isRetryable(status, code, rawMessage),
+  };
+}

--- a/lib/state/usePlaylistAnalyzer.ts
+++ b/lib/state/usePlaylistAnalyzer.ts
@@ -1,6 +1,7 @@
 "use client";
 import { normalizeMeta, normalizeTracks } from "../api/normalize";
 import { ENABLE_APPLE_MUSIC } from "@/lib/config/features";
+import { normalizeApiError, type NormalizedApiError } from "../api/errors";
 
 function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null;
@@ -167,6 +168,18 @@ export function categorizeTrack(track: PlaylistRow): TrackCategory {
 function mapTracks(rows: PlaylistRow[]): PlaylistRow[] {
   return rows;
 }
+
+function errorToMeta(error: NormalizedApiError) {
+  return {
+    status: error.status,
+    code: error.code,
+    error_code: error.code,
+    requestId: error.requestId,
+    retryable: error.retryable,
+    detail: error.detail,
+  };
+}
+
 const _sleep = (ms: number) =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -220,13 +233,11 @@ export function usePlaylistAnalyzer() {
         ),
       );
     } catch (_err) {
+      const normalized = normalizeApiError(_err);
       setMultiResults((prev) =>
         prev.map(([u, r]) =>
           u === url
-            ? [
-                u,
-                { ...r, errorText: "トラックの取得に失敗しました", tracks: [] },
-              ]
+            ? [u, { ...r, errorText: normalized.message, tracks: [] }]
             : [u, r],
         ),
       );
@@ -506,6 +517,7 @@ export function usePlaylistAnalyzer() {
     setIsReanalyzing(true);
     setLoading(false);
     setErrorText(null);
+    setErrorMeta(null);
 
     try {
       if (isBulk) {
@@ -536,6 +548,7 @@ export function usePlaylistAnalyzer() {
         }
         setMultiResults(updatedResults);
         setErrorText(null);
+        setErrorMeta(null);
         return;
       }
 
@@ -575,9 +588,12 @@ export function usePlaylistAnalyzer() {
         ),
       );
       setErrorText(null);
+      setErrorMeta(null);
     } catch (_err) {
+      const normalized = normalizeApiError(_err);
       console.error("[Re-analyze] Error:", _err);
-      setErrorText("XML照合中にエラーが発生しました");
+      setErrorMeta(errorToMeta(normalized));
+      setErrorText(normalized.message);
     } finally {
       setIsReanalyzing(false);
       setReAnalyzeUrl(null);
@@ -588,6 +604,7 @@ export function usePlaylistAnalyzer() {
   const handleAnalyze = async (e: FormEvent) => {
     e.preventDefault();
     setErrorText(null);
+    setErrorMeta(null);
     setPhaseLabel("Preparing");
     // Use forceRefreshHint from state (set by button onClick) instead of unreliable FormEvent.shiftKey
     const isForceRefresh = forceRefreshHint;
@@ -660,6 +677,26 @@ export function usePlaylistAnalyzer() {
         const isIdOnly = /^[A-Za-z0-9]{22}$/.test(url);
         if (!isSpotifyPlaylistUrl && !isSpotifyUri && !isIdOnly) {
           hasError = true;
+          setErrorText("Enter a valid Spotify playlist URL.");
+          setErrorMeta(
+            errorToMeta({
+              message: "Enter a valid Spotify playlist URL.",
+              code: "PLAYLIST_INVALID",
+              detail: { url: url.substring(0, 80) },
+              retryable: false,
+            }),
+          );
+          setProgressItems((prev) =>
+            prev.map((p) =>
+              p.url === url
+                ? {
+                    ...p,
+                    status: "error",
+                    message: "Invalid Spotify playlist URL",
+                  }
+                : p,
+            ),
+          );
           continue;
         }
 
@@ -801,11 +838,10 @@ export function usePlaylistAnalyzer() {
         });
       } catch (_err: any) {
         hasError = true;
-        // Short error message for progress list
-        const errShort =
-          typeof _err?.message === "string" ? _err.message : "request failed";
+        const normalized = normalizeApiError(_err);
+        const progressMessage = normalized.code ?? normalized.message;
         const reasonTag = false /* apple disabled */
-          ? classifyAppleError(_err?.data?.detail?.error || errShort)
+          ? classifyAppleError(String(normalized.detail ?? progressMessage))
           : null;
         setProgressItems((prev) =>
           prev.map((p) =>
@@ -813,98 +849,19 @@ export function usePlaylistAnalyzer() {
               ? {
                   ...p,
                   status: "error",
-                  message: reasonTag ? `${reasonTag}` : errShort,
+                  message: reasonTag ? `${reasonTag}` : progressMessage,
                 }
               : p,
           ),
         );
-        if (_err?.data?.detail) {
-          const detail = _err.data.detail;
-          const usedSource =
-            typeof detail?.used_source === "string"
-              ? detail.used_source
-              : undefined;
-          const errText =
-            typeof detail?.error === "string" ? detail.error : undefined;
-          const metaFromApi = detail?.meta;
-
-          // Normalize empty objects to null, but always provide minimum context
-          const normalizedMeta =
-            metaFromApi &&
-            typeof metaFromApi === "object" &&
-            Object.keys(metaFromApi).length > 0
-              ? metaFromApi
-              : null;
-
-          const detectedSource = detectSourceFromUrl(url) || "spotify";
-          const minimalContext = {
-            url: url.substring(0, 80),
-            source: usedSource || detectedSource,
-            refresh: isForceRefresh ? 1 : 0,
-            reason: reasonTag || undefined,
-          };
-
-          setErrorMeta(normalizedMeta ?? minimalContext);
-          if (usedSource === "spotify") {
-            if (errText) {
-              const lower = errText.toLowerCase();
-              const isPersonalized =
-                lower.includes("personalized") ||
-                lower.includes("private") ||
-                lower.includes("daily mix") ||
-                lower.includes("blend");
-              const isOfficial =
-                lower.includes("official editorial") ||
-                lower.includes("owner=spotify") ||
-                lower.includes("region-restricted") ||
-                lower.includes("region-locked") ||
-                lower.includes("tried markets") ||
-                lower.includes("37i9") ||
-                lower.includes("create a new public playlist");
-              if (isPersonalized && !isOfficial) {
-                setErrorText(
-                  "【日本語】\nこのSpotifyプレイリストはパーソナライズ/非公開のため、クライアントクレデンシャルでは取得できません。\nワークアラウンド: 新しい自分の公開プレイリストを作成し、元のプレイリストから全曲をコピーした上で、その新しいURLを指定してください。\n\n【English】\nThis Spotify playlist is personalized/private and cannot be accessed with client credentials.\nWorkaround: Create a new public playlist in your account, copy all tracks from the original playlist, and use the new URL.",
-                );
-              } else if (isPersonalized && isOfficial) {
-                setErrorText(
-                  "【日本語】\nこのSpotifyプレイリストは公式編集プレイリスト（37i9で始まるID）またはパーソナライズ/非公開のため、クライアントクレデンシャルでは取得できません。\nワークアラウンド: 新しい自分の公開プレイリストを作成し、元のプレイリストから全曲をコピーした上で、その新しいURLを指定してください。\n\n【English】\nThis Spotify playlist is an official editorial playlist (ID starts with 37i9) or personalized/private and cannot be accessed with client credentials.\nWorkaround: Create a new public playlist in your account, copy all tracks from the original playlist, and use the new URL.",
-                );
-              } else if (isOfficial) {
-                setErrorText(
-                  "【日本語】\nこのSpotifyの公式/編集プレイリスト（37i9で始まるID）は、地域制限や提供条件により取得できない場合があります。\nワークアラウンド: Spotifyで新しい自分の公開プレイリストを作成し、元プレイリストの曲を全てコピー、そのURLで解析してください。\n\n【English】\nThis Spotify official/editorial playlist (ID starts with 37i9) cannot be accessed due to regional restrictions or availability conditions.\nWorkaround: Create a new public playlist in Spotify, copy all tracks from the original, and use that URL for analysis.",
-                );
-              } else {
-                setErrorText(
-                  "Spotifyの取得に失敗しました / Spotify request failed: " +
-                    errText,
-                );
-              }
-            } else {
-              setErrorText("Spotifyの取得に失敗しました（詳細不明）");
-            }
-          } else {
-            // 2-3: Musicエラー詳細化
-            const base = errText || "プレイリストの取得に失敗しました";
-            const reasonSuffix =
-              false /* apple disabled */ && reasonTag ? ` (${reasonTag})` : "";
-            let hint = "";
-            if (false /* apple disabled */) {
-              if (reasonTag === "timeout") {
-                hint =
-                  "\n取得元が遅い/失敗しやすい場合があります。単体URLでRetry推奨。時間をおいて再試行してください。";
-              } else if (reasonTag === "region") {
-                hint = "\n地域制限・提供条件により取得できない場合があります。";
-              } else if (reasonTag === "bot-suspected") {
-                hint =
-                  "\n取得元側でbot判定・CAPTCHA等によりブロックされている可能性があります。時間をおいて再試行してください。";
-              }
-            }
-            setErrorText(base + reasonSuffix + hint);
-          }
-        } else {
-          const hint = reasonTag ? ` (${reasonTag})` : "";
-          setErrorText(`プレイリストの取得に失敗しました${hint}`);
-        }
+        setErrorMeta({
+          ...errorToMeta(normalized),
+          url: url.substring(0, 80),
+          source: detectSourceFromUrl(url) || "spotify",
+          refresh: isForceRefresh ? 1 : 0,
+          reason: reasonTag || undefined,
+        });
+        setErrorText(normalized.message);
       }
     }
 

--- a/tests/api-client.test.ts
+++ b/tests/api-client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { fetchJson, SchemaMismatch } from "@/lib/api/client";
+import { fetchJson } from "@/lib/api/client";
 import { PlaylistResponseSchema } from "@/lib/api/responseSchemas";
 
 describe("fetchJson", () => {
@@ -7,7 +7,7 @@ describe("fetchJson", () => {
     vi.restoreAllMocks();
   });
 
-  test("throws backend error body as-is for non-2xx responses", async () => {
+  test("throws normalized backend errors for non-2xx responses", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -23,12 +23,14 @@ describe("fetchJson", () => {
     await expect(
       fetchJson("/api/playlist", undefined, PlaylistResponseSchema),
     ).rejects.toMatchObject({
+      message: "Something went wrong. Please try again.",
       status: 400,
-      data: { detail: { error: "backend failed", used_source: "spotify" } },
+      detail: { error: "backend failed", used_source: "spotify" },
+      retryable: false,
     });
   });
 
-  test("throws SchemaMismatch for invalid 2xx payloads", async () => {
+  test("throws normalized schema mismatch for invalid 2xx payloads", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ tracks: [] }), {
         status: 200,
@@ -38,6 +40,10 @@ describe("fetchJson", () => {
 
     await expect(
       fetchJson("/api/playlist", undefined, PlaylistResponseSchema),
-    ).rejects.toBeInstanceOf(SchemaMismatch);
+    ).rejects.toMatchObject({
+      message: "Something went wrong. Please try again.",
+      detail: expect.any(Array),
+      retryable: false,
+    });
   });
 });

--- a/tests/api-error-normalization.test.ts
+++ b/tests/api-error-normalization.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, test } from "vitest";
+import { z } from "zod";
+import { normalizeApiError } from "@/lib/api/errors";
+
+describe("normalizeApiError", () => {
+  test("normal Error object", () => {
+    expect(normalizeApiError(new Error("boom"))).toMatchObject({
+      message: "Something went wrong. Please try again.",
+      retryable: false,
+    });
+  });
+
+  test("API error with status and data.detail", () => {
+    expect(
+      normalizeApiError({
+        status: 400,
+        data: {
+          detail: {
+            error: "url must be a Spotify playlist URL",
+            used_source: "spotify",
+          },
+        },
+      }),
+    ).toMatchObject({
+      message: "Enter a valid Spotify playlist URL.",
+      status: 400,
+      detail: {
+        error: "url must be a Spotify playlist URL",
+        used_source: "spotify",
+      },
+      retryable: false,
+    });
+  });
+
+  test("API error with requestId", () => {
+    expect(
+      normalizeApiError({
+        status: 503,
+        data: {
+          error: "backend_unavailable",
+          message: "upstream failed",
+          requestId: "req_123",
+        },
+      }),
+    ).toMatchObject({
+      message: "Could not reach the analysis server. Please try again.",
+      status: 503,
+      code: "backend_unavailable",
+      requestId: "req_123",
+      retryable: true,
+    });
+  });
+
+  test("AbortError / timeout", () => {
+    expect(
+      normalizeApiError(
+        new DOMException("The operation timed out", "AbortError"),
+      ),
+    ).toMatchObject({
+      message: "Analysis took too long. Please try again.",
+      retryable: true,
+    });
+  });
+
+  test("Zod validation error", () => {
+    const parsed = z.object({ tracks: z.array(z.string()) }).safeParse({});
+    expect(parsed.success).toBe(false);
+    if (parsed.success) return;
+
+    expect(normalizeApiError(parsed.error)).toMatchObject({
+      message: "Something went wrong. Please try again.",
+      detail: parsed.error.issues,
+      retryable: false,
+    });
+  });
+
+  test("unknown string", () => {
+    expect(normalizeApiError("nope")).toMatchObject({
+      message: "Something went wrong. Please try again.",
+      retryable: false,
+    });
+  });
+
+  test("unknown object", () => {
+    expect(normalizeApiError({ what: "is this" })).toMatchObject({
+      message: "Something went wrong. Please try again.",
+      retryable: false,
+    });
+  });
+
+  test("null and undefined", () => {
+    expect(normalizeApiError(null)).toMatchObject({
+      message: "Something went wrong. Please try again.",
+      retryable: false,
+    });
+    expect(normalizeApiError(undefined)).toMatchObject({
+      message: "Something went wrong. Please try again.",
+      retryable: false,
+    });
+  });
+});

--- a/tests/use-playlist-analyzer.integration.test.tsx
+++ b/tests/use-playlist-analyzer.integration.test.tsx
@@ -425,13 +425,13 @@ describe("usePlaylistAnalyzer Spotify flow", () => {
     expect(currentApi!.loading).toBe(false);
     expect(currentApi!.multiResults).toEqual([]);
     expect(currentApi!.errorText).toBe(
-      "Spotifyの取得に失敗しました / Spotify request failed: backend exploded",
+      "Something went wrong. Please try again.",
     );
     expect(currentApi!.progressItems).toEqual([
       expect.objectContaining({
         url: "https://open.spotify.com/playlist/abc123",
         status: "error",
-        message: "request failed",
+        message: "Something went wrong. Please try again.",
       }),
     ]);
   });
@@ -528,7 +528,7 @@ describe("usePlaylistAnalyzer Spotify flow", () => {
       }),
     );
     expect(currentApi!.errorText).toBe(
-      "Spotifyの取得に失敗しました / Spotify request failed: second playlist failed",
+      "Something went wrong. Please try again.",
     );
     expect(currentApi!.progressItems).toEqual([
       expect.objectContaining({
@@ -539,7 +539,7 @@ describe("usePlaylistAnalyzer Spotify flow", () => {
       expect.objectContaining({
         url: failureUrl,
         status: "error",
-        message: "request failed",
+        message: "Something went wrong. Please try again.",
       }),
     ]);
   });


### PR DESCRIPTION
Adds frontend API error normalization and routes analyzer failures through stable user-facing messages while preserving debug metadata.

Changes:
- Add frontend API error normalizer
- Preserve status, detail, code, and requestId where available
- Route analyzer failures through stable user-facing messages
- Add regression tests for common error shapes
- Update API client/analyzer tests

Validation:
- pnpm test
- pnpm exec tsc --noEmit --incremental false
- pnpm lint
- pnpm build
- git diff --check