### PR TITLE
Improve analysis loading feedback

### DIFF
--- a/app/components/AnalyzeForm.tsx
+++ b/app/components/AnalyzeForm.tsx
@@ -24,6 +24,7 @@ export interface AnalyzeFormProps {
   loading: boolean;
   isReanalyzing: boolean;
   progress: number;
+  phaseLabel?: string | null;
 
   errorText: string | null;
   errorMeta?: ErrorMeta;
@@ -259,6 +260,7 @@ export default function AnalyzeForm(props: AnalyzeFormProps) {
               analyzing={props.loading}
               reanalyzing={props.isReanalyzing}
               progress={props.progress}
+              phaseLabel={props.phaseLabel}
             />
           </div>
         ) : null}

--- a/app/components/ProcessingBar.tsx
+++ b/app/components/ProcessingBar.tsx
@@ -6,29 +6,40 @@ export interface ProcessingBarProps {
   analyzing: boolean;
   reanalyzing: boolean;
   progress: number;
+  phaseLabel?: string | null;
 }
 
 export default function ProcessingBar({
   analyzing,
   reanalyzing,
   progress,
+  phaseLabel,
 }: ProcessingBarProps) {
   if (!analyzing && !reanalyzing) return null;
-  const label = analyzing
-    ? "Analyzing playlist…"
-    : "Matching with Rekordbox XML";
+  const isFetchingSpotify = phaseLabel === "Fetching Spotify...";
+  const label =
+    phaseLabel ?? (analyzing ? "Analyzing playlist..." : "Matching Rekordbox");
   const pct = Math.max(progress, 5);
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between text-xs text-slate-300">
         <span>{label}</span>
-        <span>{Math.round(pct)}%</span>
+        <span>{isFetchingSpotify ? "Working..." : `${Math.round(pct)}%`}</span>
       </div>
+      {isFetchingSpotify ? (
+        <div className="text-xs text-slate-500">
+          First run can take a few seconds while the server wakes up.
+        </div>
+      ) : null}
       <div className="w-full h-2 bg-slate-900 rounded-full overflow-hidden border border-slate-700">
-        <div
-          className="h-full bg-gradient-to-r from-emerald-500 to-emerald-400 rounded-full transition-all duration-300"
-          style={{ width: `${pct}%` }}
-        />
+        {isFetchingSpotify ? (
+          <div className="h-full w-full animate-pulse rounded-full bg-gradient-to-r from-emerald-500/30 via-emerald-300 to-emerald-500/30" />
+        ) : (
+          <div
+            className="h-full bg-gradient-to-r from-emerald-500 to-emerald-400 rounded-full transition-all duration-300"
+            style={{ width: `${pct}%` }}
+          />
+        )}
       </div>
     </div>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -359,9 +359,6 @@ function PageInner() {
             {analyzer.isProcessing && (
               <div className="mb-3 rounded-md border border-emerald-400/20 bg-emerald-400/5 px-3 py-2 text-[11px] text-emerald-100/80">
                 {analyzer.phaseLabel || "Processing…"}
-                {analyzer.progress < 10 && (
-                  <span className="text-slate-400"> Server starting up…</span>
-                )}
               </div>
             )}
             <AnalyzeForm
@@ -381,6 +378,7 @@ function PageInner() {
               loading={analyzer.loading}
               isReanalyzing={analyzer.isReanalyzing}
               progress={analyzer.progress}
+              phaseLabel={analyzer.phaseLabel}
               errorText={analyzer.errorText}
               errorMeta={analyzer.errorMeta}
               progressItems={analyzer.progressItems}

--- a/lib/state/usePlaylistAnalyzer.ts
+++ b/lib/state/usePlaylistAnalyzer.ts
@@ -657,7 +657,7 @@ export function usePlaylistAnalyzer() {
         if (isApplePlaylistUrl) {
           effectiveSource = "spotify";
         }
-        setPhaseLabel("Fetching Spotify");
+        setPhaseLabel("Fetching Spotify...");
         setProgressItems((prev) =>
           prev.map((p) =>
             p.url === url

--- a/tests/analyze-form-paste.test.tsx
+++ b/tests/analyze-form-paste.test.tsx
@@ -18,6 +18,7 @@ function makeProps(
     loading: false,
     isReanalyzing: false,
     progress: 0,
+    phaseLabel: null,
     errorText: null,
     errorMeta: undefined,
     banner: null,
@@ -189,5 +190,33 @@ describe("AnalyzeForm", () => {
     );
 
     expect(textButton(container, "Analyze").disabled).toBe(false);
+  });
+
+  test("shows indeterminate Spotify fetch feedback while analysis is running", async () => {
+    const cancelAnalyze = vi.fn();
+
+    await renderForm(
+      makeProps({
+        playlistUrlInput: "https://open.spotify.com/playlist/abc123",
+        loading: true,
+        progress: 35,
+        phaseLabel: "Fetching Spotify...",
+        cancelAnalyze,
+      }),
+    );
+
+    expect(container.textContent).toContain("Fetching Spotify...");
+    expect(container.textContent).toContain(
+      "First run can take a few seconds while the server wakes up.",
+    );
+    expect(container.textContent).toContain("Working...");
+    expect(container.textContent).not.toContain("35%");
+    expect(textButton(container, "Analyze").disabled).toBe(true);
+
+    await act(async () => {
+      textButton(container, "Cancel").click();
+    });
+
+    expect(cancelAnalyze).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Improves cold-start/cache-miss loading feedback by showing indeterminate Spotify fetch progress with calm helper copy, while preserving cancel and existing success/error flows.

Validation:
- pnpm test
- pnpm exec tsc --noEmit --incremental false
- pnpm lint
- pnpm build
- git diff --check