### PR TITLE
Propagate abort signal through fetch timeout

### DIFF
--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -18,17 +18,33 @@ function isRetryableStatus(status: number): boolean {
   return status === 429 || status === 502 || status === 503 || status === 504;
 }
 
-async function fetchWithTimeout(
+export async function fetchWithTimeout(
   url: string,
   init: RequestInit,
   timeoutMs: number,
 ): Promise<Response> {
   const controller = new AbortController();
-  const t = setTimeout(() => controller.abort(), timeoutMs);
+  const callerSignal = init.signal;
+  const forwardCallerAbort = () => controller.abort(callerSignal?.reason);
+
+  if (callerSignal?.aborted) {
+    forwardCallerAbort();
+  } else {
+    callerSignal?.addEventListener("abort", forwardCallerAbort, { once: true });
+  }
+
+  const t = setTimeout(
+    () =>
+      controller.abort(
+        new DOMException("The operation timed out", "AbortError"),
+      ),
+    timeoutMs,
+  );
   try {
     return await fetch(url, { ...init, signal: controller.signal });
   } finally {
     clearTimeout(t);
+    callerSignal?.removeEventListener("abort", forwardCallerAbort);
   }
 }
 
@@ -55,6 +71,7 @@ export async function fetchWithRetry(
       continue;
     } catch (e) {
       lastErr = e;
+      if (init.signal?.aborted) throw e;
       if (attempt === retries) throw e;
 
       const base = 400 * Math.pow(2, attempt);

--- a/lib/state/usePlaylistAnalyzer.ts
+++ b/lib/state/usePlaylistAnalyzer.ts
@@ -634,7 +634,8 @@ export function usePlaylistAnalyzer() {
         abortRef.current.abort();
       } catch {}
     }
-    abortRef.current = new AbortController();
+    const requestController = new AbortController();
+    abortRef.current = requestController;
     const localRequestId = requestIdRef.current + 1;
     requestIdRef.current = localRequestId;
 
@@ -710,14 +711,14 @@ export function usePlaylistAnalyzer() {
               source: effectiveSource,
               file: activeRekordboxFile,
               refresh: isForceRefresh,
-              signal: abortRef.current?.signal ?? undefined,
+              signal: requestController.signal,
             });
           }
           return getPlaylist({
             url,
             source: effectiveSource,
             refresh: isForceRefresh,
-            signal: abortRef.current?.signal ?? undefined,
+            signal: requestController.signal,
           });
         };
 
@@ -837,6 +838,12 @@ export function usePlaylistAnalyzer() {
           });
         });
       } catch (_err: any) {
+        if (
+          requestController.signal.aborted ||
+          localRequestId !== requestIdRef.current
+        ) {
+          break;
+        }
         hasError = true;
         const normalized = normalizeApiError(_err);
         const progressMessage = normalized.code ?? normalized.message;
@@ -864,6 +871,8 @@ export function usePlaylistAnalyzer() {
         setErrorText(normalized.message);
       }
     }
+
+    if (localRequestId !== requestIdRef.current) return;
 
     if (newResults.length > 0) {
       const rbMeta = makeRekordboxMeta(activeRekordboxFile);
@@ -1053,6 +1062,7 @@ export function usePlaylistAnalyzer() {
   };
 
   const cancelAnalyze = () => {
+    requestIdRef.current += 1;
     try {
       abortRef.current?.abort();
     } catch {

--- a/tests/api-client.test.ts
+++ b/tests/api-client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { fetchJson } from "@/lib/api/client";
+import { fetchJson, fetchWithTimeout } from "@/lib/api/client";
 import { PlaylistResponseSchema } from "@/lib/api/responseSchemas";
 
 describe("fetchJson", () => {
@@ -45,5 +45,92 @@ describe("fetchJson", () => {
       detail: expect.any(Array),
       retryable: false,
     });
+  });
+});
+
+describe("fetchWithTimeout", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  test("aborts the fetch when the caller signal aborts", async () => {
+    const caller = new AbortController();
+    let fetchSignal: AbortSignal | undefined;
+    vi.spyOn(globalThis, "fetch").mockImplementation((_url, init) => {
+      fetchSignal = init?.signal ?? undefined;
+      return new Promise((_resolve, reject) => {
+        fetchSignal?.addEventListener("abort", () =>
+          reject(fetchSignal?.reason),
+        );
+      });
+    });
+
+    const request = fetchWithTimeout(
+      "/api/playlist",
+      { method: "POST", signal: caller.signal },
+      25_000,
+    );
+    caller.abort();
+
+    await expect(request).rejects.toMatchObject({ name: "AbortError" });
+    expect(fetchSignal?.aborted).toBe(true);
+  });
+
+  test("passes an already-aborted caller signal to fetch", async () => {
+    const caller = new AbortController();
+    caller.abort();
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(caller.signal.reason);
+
+    await expect(
+      fetchWithTimeout("/api/playlist", { signal: caller.signal }, 25_000),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+  });
+
+  test("aborts on timeout without dropping other fetch init fields", async () => {
+    vi.useFakeTimers();
+    let fetchSignal: AbortSignal | undefined;
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation((_url, init) => {
+        fetchSignal = init?.signal ?? undefined;
+        return new Promise((_resolve, reject) => {
+          fetchSignal?.addEventListener("abort", () =>
+            reject(fetchSignal?.reason),
+          );
+        });
+      });
+
+    const request = fetchWithTimeout(
+      "/api/playlist",
+      { method: "POST", headers: { "x-test": "yes" } },
+      100,
+    );
+    const rejection = expect(request).rejects.toMatchObject({
+      name: "AbortError",
+    });
+    await vi.advanceTimersByTimeAsync(100);
+
+    await rejection;
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/playlist",
+      expect.objectContaining({
+        method: "POST",
+        headers: { "x-test": "yes" },
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  test("clears the timeout after a successful fetch", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null));
+
+    await fetchWithTimeout("/api/playlist", {}, 100);
+
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/tests/use-playlist-analyzer.integration.test.tsx
+++ b/tests/use-playlist-analyzer.integration.test.tsx
@@ -436,6 +436,43 @@ describe("usePlaylistAnalyzer Spotify flow", () => {
     ]);
   });
 
+  test("Cancel aborts the request without showing a generic failure", async () => {
+    let requestSignal: AbortSignal | undefined;
+    getPlaylistMock.mockImplementation(
+      ({ signal }: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          requestSignal = signal;
+          signal?.addEventListener("abort", () => reject(signal.reason));
+        }),
+    );
+
+    await act(async () => {
+      root.render(<Harness onRender={(api) => void (currentApi = api)} />);
+    });
+    act(() => {
+      currentApi!.setPlaylistUrlInput(spotifyPlaylistUrl);
+    });
+
+    let analysis: Promise<void>;
+    act(() => {
+      analysis = currentApi!.handleAnalyze({
+        preventDefault() {},
+      } as FormEvent);
+    });
+    await flush();
+    act(() => {
+      currentApi!.cancelAnalyze();
+    });
+    await act(async () => {
+      await analysis!;
+    });
+
+    expect(requestSignal?.aborted).toBe(true);
+    expect(currentApi!.loading).toBe(false);
+    expect(currentApi!.progressItems).toEqual([]);
+    expect(currentApi!.errorText).toBeNull();
+  });
+
   test("keeps only the successful result during a mixed multi-URL run", async () => {
     const successUrl = "https://open.spotify.com/playlist/success123";
     const failureUrl = "https://open.spotify.com/playlist/failure456";


### PR DESCRIPTION
Ensures caller AbortSignal is preserved when applying frontend fetch timeouts, so Cancel and timeout behavior both work reliably.

Changes:
- Compose caller abort signal with timeout abort signal
- Preserve timeout cleanup
- Keep analyzer cancellation behavior stable
- Add regression tests for caller abort and timeout behavior

Validation:
- pnpm test
- pnpm exec tsc --noEmit --incremental false
- pnpm lint
- pnpm build
- git diff --check