### PR TITLE
Remove duplicate fetching status

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -356,11 +356,6 @@ function PageInner() {
                 </ul>
               </div>
             </header>
-            {analyzer.isProcessing && (
-              <div className="mb-3 rounded-md border border-emerald-400/20 bg-emerald-400/5 px-3 py-2 text-[11px] text-emerald-100/80">
-                {analyzer.phaseLabel || "Processing…"}
-              </div>
-            )}
             <AnalyzeForm
               playlistUrlInput={analyzer.playlistUrlInput}
               setPlaylistUrlInput={analyzer.setPlaylistUrlInput}

--- a/tests/analyze-form-paste.test.tsx
+++ b/tests/analyze-form-paste.test.tsx
@@ -205,7 +205,9 @@ describe("AnalyzeForm", () => {
       }),
     );
 
-    expect(container.textContent).toContain("Fetching Spotify...");
+    expect(
+      container.textContent?.match(/Fetching Spotify\.\.\./g),
+    ).toHaveLength(1);
     expect(container.textContent).toContain(
       "First run can take a few seconds while the server wakes up.",
     );


### PR DESCRIPTION
Removes the redundant top loading status so analysis progress is shown once in the main ProcessingBar.

Changes:
- Suppress duplicate Fetching Spotify status during analysis
- Keep main ProcessingBar loading feedback
- Preserve validation errors, Cancel behavior, and invalid URL handling

Validation:
- pnpm test
- pnpm exec tsc --noEmit --incremental false
- pnpm lint
- pnpm build
- git diff --check