### PR TITLE
Remove duplicate loading status

### DIFF
--- a/app/api/_proxy.ts
+++ b/app/api/_proxy.ts
@@ -15,7 +15,7 @@ const OPEN_SPOTIFY_HOST = ["open", "spotify", "com"].join(".");
 const SPOTIFY_PLAYLIST_ID_RE = /^[A-Za-z0-9]{22}$/;
 const SPOTIFY_PLAYLIST_URI_RE = /^spotify:playlist:[A-Za-z0-9]{22}$/;
 const INVALID_SPOTIFY_PLAYLIST_MESSAGE =
-  "Enter a valid Spotify playlist URL, URI, or playlist ID.";
+  "Enter a Spotify playlist URL, URI, or ID.";
 
 const HOP_BY_HOP = new Set([
   "connection",

--- a/app/components/AnalyzeForm.tsx
+++ b/app/components/AnalyzeForm.tsx
@@ -81,7 +81,7 @@ export default function AnalyzeForm(props: AnalyzeFormProps) {
   const playlistUrlError = useMemo(() => {
     const code = props.errorMeta?.error_code;
     if (code === "PLAYLIST_INVALID")
-      return messageFromMeta ?? "Invalid playlist URL";
+      return messageFromMeta ?? "Enter a Spotify playlist URL, URI, or ID.";
     return null;
   }, [props.errorMeta, messageFromMeta]);
 
@@ -219,7 +219,8 @@ export default function AnalyzeForm(props: AnalyzeFormProps) {
           </div>
           {props.playlistUrlError || playlistUrlError ? (
             <div className="text-xs text-rose-300">
-              {props.playlistUrlError || playlistUrlError}
+              <div className="font-semibold">Invalid playlist input</div>
+              <div>{props.playlistUrlError || playlistUrlError}</div>
             </div>
           ) : null}
           {localXmlError ? (
@@ -265,7 +266,7 @@ export default function AnalyzeForm(props: AnalyzeFormProps) {
           </div>
         ) : null}
 
-        {props.errorText ? (
+        {props.errorText && !playlistUrlError ? (
           <div className="pt-2">
             <ErrorAlert
               title="Error"

--- a/lib/api/errors.ts
+++ b/lib/api/errors.ts
@@ -103,7 +103,7 @@ function userMessage(input: {
       raw,
     )
   ) {
-    return "Enter a valid Spotify playlist URL.";
+    return "Enter a Spotify playlist URL, URI, or ID.";
   }
 
   if (/xml|rekordbox|match_snapshot|matching/.test(raw)) {

--- a/lib/state/usePlaylistAnalyzer.ts
+++ b/lib/state/usePlaylistAnalyzer.ts
@@ -3,6 +3,26 @@ import { normalizeMeta, normalizeTracks } from "../api/normalize";
 import { ENABLE_APPLE_MUSIC } from "@/lib/config/features";
 import { normalizeApiError, type NormalizedApiError } from "../api/errors";
 
+const INVALID_PLAYLIST_MESSAGE = "Enter a Spotify playlist URL, URI, or ID.";
+
+function isSpotifyPlaylistInput(value: string): boolean {
+  if (/^spotify:playlist:[A-Za-z0-9]{22}$/i.test(value)) return true;
+  if (/^[A-Za-z0-9]{22}$/.test(value)) return true;
+
+  try {
+    const url = new URL(value);
+    const [, type, id] = url.pathname.split("/");
+    return (
+      (url.protocol === "https:" || url.protocol === "http:") &&
+      url.hostname.toLowerCase() === "open.spotify.com" &&
+      type === "playlist" &&
+      Boolean(id)
+    );
+  } catch {
+    return false;
+  }
+}
+
 function isRecord(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null;
 }
@@ -622,6 +642,21 @@ export function usePlaylistAnalyzer() {
       return;
     }
 
+    const invalidUrl = urls.find((url) => !isSpotifyPlaylistInput(url));
+    if (invalidUrl) {
+      setErrorText(INVALID_PLAYLIST_MESSAGE);
+      setErrorMeta(
+        errorToMeta({
+          message: INVALID_PLAYLIST_MESSAGE,
+          code: "PLAYLIST_INVALID",
+          detail: { url: invalidUrl.substring(0, 80) },
+          retryable: false,
+        }),
+      );
+      setPhaseLabel(null);
+      return;
+    }
+
     const activeRekordboxFile = await resolveActiveRekordboxFile();
 
     // Initialize progress items for each URL
@@ -670,36 +705,6 @@ export function usePlaylistAnalyzer() {
               : p,
           ),
         );
-
-        const isSpotifyPlaylistUrl = /open\.spotify\.com\/.*playlist\//i.test(
-          url,
-        );
-        const isSpotifyUri = /^spotify:playlist:[A-Za-z0-9]{22}$/i.test(url);
-        const isIdOnly = /^[A-Za-z0-9]{22}$/.test(url);
-        if (!isSpotifyPlaylistUrl && !isSpotifyUri && !isIdOnly) {
-          hasError = true;
-          setErrorText("Enter a valid Spotify playlist URL.");
-          setErrorMeta(
-            errorToMeta({
-              message: "Enter a valid Spotify playlist URL.",
-              code: "PLAYLIST_INVALID",
-              detail: { url: url.substring(0, 80) },
-              retryable: false,
-            }),
-          );
-          setProgressItems((prev) =>
-            prev.map((p) =>
-              p.url === url
-                ? {
-                    ...p,
-                    status: "error",
-                    message: "Invalid Spotify playlist URL",
-                  }
-                : p,
-            ),
-          );
-          continue;
-        }
 
         const t2_api_start = performance.now();
         let json: unknown | null = null;

--- a/tests/analyze-form-paste.test.tsx
+++ b/tests/analyze-form-paste.test.tsx
@@ -221,4 +221,24 @@ describe("AnalyzeForm", () => {
 
     expect(cancelAnalyze).toHaveBeenCalledTimes(1);
   });
+
+  test("shows invalid playlist errors beside the input", async () => {
+    await renderForm(
+      makeProps({
+        playlistUrlInput:
+          "https://open.spotify.com/album/588N4Kt4446o660ARpswUD",
+        errorText: "Enter a Spotify playlist URL, URI, or ID.",
+        errorMeta: {
+          error_code: "PLAYLIST_INVALID",
+          message: "Enter a Spotify playlist URL, URI, or ID.",
+        },
+      }),
+    );
+
+    expect(container.textContent).toContain("Invalid playlist input");
+    expect(container.textContent).toContain(
+      "Enter a Spotify playlist URL, URI, or ID.",
+    );
+    expect(container.textContent).not.toContain("Show refresh tips");
+  });
 });

--- a/tests/api-error-normalization.test.ts
+++ b/tests/api-error-normalization.test.ts
@@ -22,7 +22,7 @@ describe("normalizeApiError", () => {
         },
       }),
     ).toMatchObject({
-      message: "Enter a valid Spotify playlist URL.",
+      message: "Enter a Spotify playlist URL, URI, or ID.",
       status: 400,
       detail: {
         error: "url must be a Spotify playlist URL",

--- a/tests/spotify-playlist-input-validation.test.ts
+++ b/tests/spotify-playlist-input-validation.test.ts
@@ -1,15 +1,14 @@
 import { describe, expect, test } from "vitest";
 import { validateSpotifyPlaylistInput } from "@/app/api/_proxy";
 
-const playlistId = "6ImtrR8i2iwQrk2jrdRGOo";
-const invalidMessage =
-  "Enter a valid Spotify playlist URL, URI, or playlist ID.";
+const playlistId = "588N4Kt4446o660ARpswUD";
+const invalidMessage = "Enter a Spotify playlist URL, URI, or ID.";
 
 describe("validateSpotifyPlaylistInput", () => {
   test.each([
     [
       "full URL with query string",
-      `https://open.spotify.com/playlist/${playlistId}?si=abc123`,
+      `https://open.spotify.com/playlist/${playlistId}?si=99a8b205eabf4bb0`,
     ],
     [
       "full URL without query string",

--- a/tests/use-playlist-analyzer.integration.test.tsx
+++ b/tests/use-playlist-analyzer.integration.test.tsx
@@ -226,6 +226,33 @@ describe("usePlaylistAnalyzer Spotify flow", () => {
     ]);
   });
 
+  test("rejects a Spotify album URL before analysis starts", async () => {
+    await act(async () => {
+      root.render(<Harness onRender={(api) => void (currentApi = api)} />);
+    });
+
+    act(() => {
+      currentApi!.setPlaylistUrlInput(
+        "https://open.spotify.com/album/588N4Kt4446o660ARpswUD",
+      );
+    });
+
+    await act(async () => {
+      await currentApi!.handleAnalyze({ preventDefault() {} } as FormEvent);
+    });
+
+    expect(currentApi!.loading).toBe(false);
+    expect(currentApi!.phaseLabel).toBeNull();
+    expect(currentApi!.errorText).toBe(
+      "Enter a Spotify playlist URL, URI, or ID.",
+    );
+    expect(currentApi!.errorMeta).toEqual(
+      expect.objectContaining({ error_code: "PLAYLIST_INVALID" }),
+    );
+    expect(getPlaylistMock).not.toHaveBeenCalled();
+    expect(postPlaylistWithRekordboxUploadMock).not.toHaveBeenCalled();
+  });
+
   test("uses uploaded Rekordbox XML on the main Analyze action", async () => {
     const file = new File(["<DJ_PLAYLISTS />"], "collection.xml", {
       type: "text/xml",


### PR DESCRIPTION
Removes duplicated analysis phase text so ProcessingBar is the only source of truth for Fetching Spotify status.

Changes:
- Hide duplicate top analysis status while analyzing
- Keep validation errors near the input
- Verify invalid Spotify album URL handling
- Update invalid playlist copy if needed
- Add/update focused tests

Validation:
- pnpm test
- pnpm exec tsc --noEmit --incremental false
- pnpm lint
- pnpm build
- git diff --check
