### PR TITLE
Add mobile desktop handoff flow

### DIFF
--- a/app/components/AnalyzeForm.tsx
+++ b/app/components/AnalyzeForm.tsx
@@ -5,6 +5,7 @@ import ProcessingBar from "./ProcessingBar";
 import ErrorAlert from "./ErrorAlert";
 import type { ProgressItem } from "./ProgressList";
 import type { SavedRekordboxXmlMeta } from "@/lib/storage/savedRekordboxXml";
+import MobileDesktopHandoff from "./MobileDesktopHandoff";
 
 type ErrorMeta = {
   error_code: string;
@@ -110,6 +111,10 @@ export default function AnalyzeForm(props: AnalyzeFormProps) {
 
   return (
     <section className="w-full space-y-8">
+      <MobileDesktopHandoff
+        playlistInput={props.playlistUrlInput}
+        focusPlaylistInput={() => playlistInputRef.current?.focus()}
+      />
       {props.banner?.text ? (
         <div
           className={`rounded-md border px-3 py-2 text-xs ${
@@ -189,6 +194,13 @@ export default function AnalyzeForm(props: AnalyzeFormProps) {
               </button>
             ) : null}
           </div>
+        </div>
+
+        <div className="-mt-6 text-xs leading-5 text-slate-500">
+          <span className="font-medium text-slate-400">
+            Need your Rekordbox XML?
+          </span>{" "}
+          Export your Rekordbox collection as XML, then upload it here.
         </div>
 
         <div className="space-y-2">

--- a/app/components/MobileDesktopHandoff.tsx
+++ b/app/components/MobileDesktopHandoff.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import {
+  buildDesktopHandoffLink,
+  isValidSpotifyPlaylistInput,
+} from "@/lib/utils/desktopHandoff";
+
+export default function MobileDesktopHandoff({
+  playlistInput,
+  focusPlaylistInput,
+}: {
+  playlistInput: string;
+  focusPlaylistInput: () => void;
+}) {
+  const [copied, setCopied] = useState(false);
+  const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (copiedTimer.current) clearTimeout(copiedTimer.current);
+    },
+    [],
+  );
+  const valid = isValidSpotifyPlaylistInput(playlistInput);
+  const desktopLink = useMemo(() => {
+    if (!valid || typeof window === "undefined") return "";
+    return buildDesktopHandoffLink(window.location.origin, playlistInput);
+  }, [playlistInput, valid]);
+
+  const copyDesktopLink = async () => {
+    if (!desktopLink) return;
+    await navigator.clipboard.writeText(desktopLink);
+    setCopied(true);
+    if (copiedTimer.current) clearTimeout(copiedTimer.current);
+    copiedTimer.current = setTimeout(() => setCopied(false), 2000);
+  };
+
+  const emailHref = desktopLink
+    ? `mailto:?subject=${encodeURIComponent("Playlist Shopper desktop link")}&body=${encodeURIComponent(
+        `Open this on your computer:\n${desktopLink}\n\nThen export your Rekordbox XML and upload it to check which tracks are missing.`,
+      )}`
+    : undefined;
+
+  return (
+    <aside className="rounded-xl border border-sky-400/20 bg-sky-400/[0.06] p-5 md:hidden">
+      <div className="space-y-2">
+        <h2 className="text-lg font-semibold text-white">
+          Use this on your computer
+        </h2>
+        <p className="text-sm leading-6 text-slate-300">
+          Playlist Shopper needs your Rekordbox XML, so the final check works
+          best on desktop.
+        </p>
+      </div>
+      <div className="mt-4 flex flex-wrap gap-2">
+        <button
+          type="button"
+          onClick={focusPlaylistInput}
+          className="rounded-md border border-white/15 px-3 py-2 text-sm font-medium text-slate-100 hover:border-white/30"
+        >
+          Paste playlist
+        </button>
+        <button
+          type="button"
+          onClick={copyDesktopLink}
+          disabled={!desktopLink}
+          className="rounded-md bg-white px-3 py-2 text-sm font-semibold text-slate-950 hover:bg-slate-200 disabled:bg-white/10 disabled:text-white/30"
+        >
+          {copied ? "Copied" : "Copy desktop link"}
+        </button>
+        <a
+          href={emailHref}
+          aria-disabled={!emailHref}
+          onClick={(event) => {
+            if (!emailHref) event.preventDefault();
+          }}
+          className={`rounded-md border px-3 py-2 text-sm font-medium ${
+            emailHref
+              ? "border-white/15 text-slate-100 hover:border-white/30"
+              : "pointer-events-none border-white/5 text-white/30"
+          }`}
+        >
+          Email to myself
+        </a>
+      </div>
+      {!playlistInput.trim() ? (
+        <p className="mt-3 text-xs text-slate-400">
+          Paste a playlist first to create your desktop link.
+        </p>
+      ) : !valid ? (
+        <p className="mt-3 text-xs text-rose-300">
+          Enter a valid Spotify playlist URL, URI, or ID first.
+        </p>
+      ) : null}
+    </aside>
+  );
+}

--- a/app/components/PlaylistQueryPrefill.tsx
+++ b/app/components/PlaylistQueryPrefill.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useSearchParams } from "next/navigation";
+import { playlistFromSearchParams } from "@/lib/utils/desktopHandoff";
+
+export default function PlaylistQueryPrefill({
+  setPlaylistUrlInput,
+}: {
+  setPlaylistUrlInput: (value: string) => void;
+}) {
+  const searchParams = useSearchParams();
+  const applied = useRef(false);
+
+  useEffect(() => {
+    if (applied.current) return;
+    applied.current = true;
+
+    const playlist = playlistFromSearchParams(searchParams);
+    if (playlist) setPlaylistUrlInput(playlist);
+  }, [searchParams, setPlaylistUrlInput]);
+
+  return null;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -42,6 +42,7 @@ import { useBuyQueue } from "../lib/state/useBuyQueue";
 import { categoryLabels } from "../lib/ui/selectors";
 import { getOtherStores as _getOtherStores } from "../lib/playlist/stores";
 import AnalyzeForm from "./components/AnalyzeForm";
+import PlaylistQueryPrefill from "./components/PlaylistQueryPrefill";
 import _ProgressList from "./components/ProgressList";
 import { ShopperHeader as _ShopperHeader } from "./components/ShopperHeader";
 import { ResultsTabs } from "./components/ResultsTabs";
@@ -329,6 +330,9 @@ function PageInner() {
 
   return (
     <main className="min-h-screen bg-[#04060a] text-slate-50">
+      <PlaylistQueryPrefill
+        setPlaylistUrlInput={analyzer.setPlaylistUrlInput}
+      />
       <div className="mx-auto max-w-[1024px] px-4 py-12 sm:px-6 lg:py-14">
         <div className="space-y-12">
           <section>

--- a/lib/utils/desktopHandoff.ts
+++ b/lib/utils/desktopHandoff.ts
@@ -1,0 +1,33 @@
+const SPOTIFY_PLAYLIST_ID = /^[A-Za-z0-9]{22}$/;
+const SPOTIFY_PLAYLIST_URI = /^spotify:playlist:[A-Za-z0-9]{22}$/i;
+
+export function isValidSpotifyPlaylistInput(raw: string): boolean {
+  const input = raw.trim();
+  if (SPOTIFY_PLAYLIST_ID.test(input) || SPOTIFY_PLAYLIST_URI.test(input)) {
+    return true;
+  }
+
+  try {
+    const url = new URL(input);
+    const [, type, id] = url.pathname.split("/");
+    return (
+      (url.protocol === "https:" || url.protocol === "http:") &&
+      url.hostname.toLowerCase() === "open.spotify.com" &&
+      type === "playlist" &&
+      SPOTIFY_PLAYLIST_ID.test(id ?? "")
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function buildDesktopHandoffLink(origin: string, input: string): string {
+  return `${origin}?playlist=${encodeURIComponent(input.trim())}`;
+}
+
+export function playlistFromSearchParams(
+  searchParams: Pick<URLSearchParams, "get">,
+): string | null {
+  const playlist = searchParams.get("playlist");
+  return playlist?.trim() ? playlist : null;
+}

--- a/tests/analyze-form-paste.test.tsx
+++ b/tests/analyze-form-paste.test.tsx
@@ -83,7 +83,10 @@ describe("AnalyzeForm", () => {
     expect(container.textContent).toContain("Upload Rekordbox XML");
     expect(textButton(container, "Upload")).toBeDefined();
     expect(container.textContent).not.toContain("Remove");
-    expect(container.textContent).not.toContain("Paste");
+    expect(container.textContent).toContain("Need your Rekordbox XML?");
+    expect(container.textContent).toContain(
+      "Export your Rekordbox collection as XML, then upload it here.",
+    );
   });
 
   test("renders saved XML metadata and saved XML actions", async () => {

--- a/tests/mobile-desktop-handoff.test.tsx
+++ b/tests/mobile-desktop-handoff.test.tsx
@@ -1,0 +1,120 @@
+import React, { act, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import MobileDesktopHandoff from "@/app/components/MobileDesktopHandoff";
+import PlaylistQueryPrefill from "@/app/components/PlaylistQueryPrefill";
+
+const navigation = vi.hoisted(() => ({
+  searchParams: new URLSearchParams(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => navigation.searchParams,
+}));
+
+const playlistId = "588N4Kt4446o660ARpswUD";
+
+function PrefillHarness() {
+  const [value, setValue] = useState("");
+  return (
+    <>
+      <PlaylistQueryPrefill setPlaylistUrlInput={setValue} />
+      <textarea aria-label="Playlist" value={value} readOnly />
+    </>
+  );
+}
+
+describe("mobile desktop handoff", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    navigation.searchParams = new URLSearchParams();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.restoreAllMocks();
+  });
+
+  test.each([
+    playlistId,
+    `https://open.spotify.com/playlist/${playlistId}?si=handoff`,
+    `spotify:playlist:${playlistId}`,
+  ])(
+    "prefills the playlist input from an encoded query value: %s",
+    async (value) => {
+      navigation.searchParams = new URLSearchParams(
+        `playlist=${encodeURIComponent(value)}`,
+      );
+
+      await act(async () => root.render(<PrefillHarness />));
+
+      expect(
+        (container.querySelector("textarea") as HTMLTextAreaElement).value,
+      ).toBe(value);
+    },
+  );
+
+  test("leaves the existing desktop input empty without a playlist query", async () => {
+    await act(async () => root.render(<PrefillHarness />));
+
+    expect(
+      (container.querySelector("textarea") as HTMLTextAreaElement).value,
+    ).toBe("");
+  });
+
+  test("renders the mobile handoff panel for a small viewport", async () => {
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 390,
+    });
+
+    await act(async () =>
+      root.render(
+        <MobileDesktopHandoff playlistInput="" focusPlaylistInput={vi.fn()} />,
+      ),
+    );
+
+    const panel = container.querySelector("aside");
+    expect(panel?.className).toContain("md:hidden");
+    expect(container.textContent).toContain("Use this on your computer");
+    expect(container.textContent).toContain(
+      "Paste a playlist first to create your desktop link.",
+    );
+  });
+
+  test("copies a desktop URL containing the encoded playlist input", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+
+    const playlist = `https://open.spotify.com/playlist/${playlistId}?si=abc`;
+    await act(async () =>
+      root.render(
+        <MobileDesktopHandoff
+          playlistInput={playlist}
+          focusPlaylistInput={vi.fn()}
+        />,
+      ),
+    );
+
+    const copyButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Copy desktop link",
+    );
+    await act(async () => copyButton?.click());
+
+    expect(writeText).toHaveBeenCalledWith(
+      `${window.location.origin}?playlist=${encodeURIComponent(playlist)}`,
+    );
+    expect(copyButton?.textContent).toBe("Copied");
+  });
+});


### PR DESCRIPTION
Adds a lightweight mobile-to-desktop handoff so users who receive Playlist Shopper on mobile can save a prepared desktop link and continue later with Rekordbox XML.

Changes:
- Support playlist query param prefill
- Add mobile handoff panel
- Add copy desktop link action
- Add email-to-self mailto action
- Add compact Rekordbox XML helper copy
- Preserve existing desktop analyze flow

Validation:
- pnpm test
- pnpm exec tsc --noEmit --incremental false
- pnpm lint
- pnpm build
- git diff --check
