### PR TITLE
Fix desktop link playlist source

### DIFF
--- a/app/components/AnalyzeForm.tsx
+++ b/app/components/AnalyzeForm.tsx
@@ -15,6 +15,9 @@ type ErrorMeta = {
 
 export interface AnalyzeFormProps {
   playlistUrlInput: string;
+  activePlaylistInput?: string | null;
+  activePlaylistId?: string | null;
+  queryPlaylist?: string | null;
   rekordboxFile: File | null;
   rekordboxDate?: string | null;
   rekordboxFilename?: string | null;
@@ -113,6 +116,9 @@ export default function AnalyzeForm(props: AnalyzeFormProps) {
     <section className="w-full space-y-8">
       <MobileDesktopHandoff
         playlistInput={props.playlistUrlInput}
+        activePlaylistInput={props.activePlaylistInput}
+        activePlaylistId={props.activePlaylistId}
+        queryPlaylist={props.queryPlaylist}
         focusPlaylistInput={() => playlistInputRef.current?.focus()}
       />
       {props.banner?.text ? (

--- a/app/components/MobileDesktopHandoff.tsx
+++ b/app/components/MobileDesktopHandoff.tsx
@@ -3,14 +3,23 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   buildDesktopHandoffLink,
-  isValidSpotifyPlaylistInput,
+  getHandoffPlaylistSource,
+  hasHandoffPlaylistSource,
 } from "@/lib/utils/desktopHandoff";
 
 export default function MobileDesktopHandoff({
+  handoffInput,
   playlistInput,
+  activePlaylistInput,
+  activePlaylistId,
+  queryPlaylist,
   focusPlaylistInput,
 }: {
+  handoffInput?: string | null;
   playlistInput: string;
+  activePlaylistInput?: string | null;
+  activePlaylistId?: string | null;
+  queryPlaylist?: string | null;
   focusPlaylistInput: () => void;
 }) {
   const [copied, setCopied] = useState(false);
@@ -21,11 +30,21 @@ export default function MobileDesktopHandoff({
     },
     [],
   );
-  const valid = isValidSpotifyPlaylistInput(playlistInput);
+  const playlistSources = {
+    handoffInput,
+    playlistInput,
+    activePlaylist: {
+      sourceInput: activePlaylistInput,
+      id: activePlaylistId,
+    },
+    queryPlaylist,
+  };
+  const sourcePlaylistInput = getHandoffPlaylistSource(playlistSources);
+  const hasPlaylistSource = hasHandoffPlaylistSource(playlistSources);
   const desktopLink = useMemo(() => {
-    if (!valid || typeof window === "undefined") return "";
-    return buildDesktopHandoffLink(window.location.origin, playlistInput);
-  }, [playlistInput, valid]);
+    if (!sourcePlaylistInput || typeof window === "undefined") return "";
+    return buildDesktopHandoffLink(window.location.origin, sourcePlaylistInput);
+  }, [sourcePlaylistInput]);
 
   const copyDesktopLink = async () => {
     if (!desktopLink) return;
@@ -83,11 +102,11 @@ export default function MobileDesktopHandoff({
           Email to myself
         </a>
       </div>
-      {!playlistInput.trim() ? (
+      {!hasPlaylistSource ? (
         <p className="mt-3 text-xs text-slate-400">
           Paste a playlist first to create your desktop link.
         </p>
-      ) : !valid ? (
+      ) : !sourcePlaylistInput ? (
         <p className="mt-3 text-xs text-rose-300">
           Enter a valid Spotify playlist URL, URI, or ID first.
         </p>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -362,6 +362,11 @@ function PageInner() {
             </header>
             <AnalyzeForm
               playlistUrlInput={analyzer.playlistUrlInput}
+              activePlaylistInput={
+                selection.activeTab ?? vm.currentResult?.playlistUrl
+              }
+              activePlaylistId={vm.currentResult?.playlist_id}
+              queryPlaylist={searchParams.get("playlist")}
               setPlaylistUrlInput={analyzer.setPlaylistUrlInput}
               handleAnalyze={handleAnalyzeWithAppleBlock}
               rekordboxFile={analyzer.rekordboxFile}

--- a/lib/utils/desktopHandoff.ts
+++ b/lib/utils/desktopHandoff.ts
@@ -25,6 +25,50 @@ export function buildDesktopHandoffLink(origin: string, input: string): string {
   return `${origin}?playlist=${encodeURIComponent(input.trim())}`;
 }
 
+export type HandoffPlaylistSources = {
+  handoffInput?: string | null;
+  playlistInput?: string | null;
+  activePlaylist?: {
+    sourceInput?: string | null;
+    playlistInput?: string | null;
+    id?: string | null;
+  } | null;
+  queryPlaylist?: string | null;
+};
+
+function handoffPlaylistCandidates({
+  handoffInput,
+  playlistInput,
+  activePlaylist,
+  queryPlaylist,
+}: HandoffPlaylistSources) {
+  return [
+    handoffInput,
+    playlistInput,
+    activePlaylist?.sourceInput,
+    activePlaylist?.playlistInput,
+    activePlaylist?.id,
+    queryPlaylist,
+  ];
+}
+
+export function hasHandoffPlaylistSource(sources: HandoffPlaylistSources) {
+  return handoffPlaylistCandidates(sources).some((candidate) =>
+    Boolean(candidate?.trim()),
+  );
+}
+
+export function getHandoffPlaylistSource(
+  sources: HandoffPlaylistSources,
+): string | null {
+  for (const candidate of handoffPlaylistCandidates(sources)) {
+    const source = candidate?.trim();
+    if (source && isValidSpotifyPlaylistInput(source)) return source;
+  }
+
+  return null;
+}
+
 export function playlistFromSearchParams(
   searchParams: Pick<URLSearchParams, "get">,
 ): string | null {

--- a/tests/mobile-desktop-handoff.test.tsx
+++ b/tests/mobile-desktop-handoff.test.tsx
@@ -43,6 +43,23 @@ describe("mobile desktop handoff", () => {
     vi.restoreAllMocks();
   });
 
+  function mockClipboard() {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    return writeText;
+  }
+
+  async function clickCopy() {
+    const copyButton = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Copy desktop link",
+    );
+    await act(async () => copyButton?.click());
+    return copyButton;
+  }
+
   test.each([
     playlistId,
     `https://open.spotify.com/playlist/${playlistId}?si=handoff`,
@@ -90,31 +107,107 @@ describe("mobile desktop handoff", () => {
     );
   });
 
-  test("copies a desktop URL containing the encoded playlist input", async () => {
-    const writeText = vi.fn().mockResolvedValue(undefined);
-    Object.defineProperty(navigator, "clipboard", {
-      configurable: true,
-      value: { writeText },
-    });
-
-    const playlist = `https://open.spotify.com/playlist/${playlistId}?si=abc`;
+  test("uses handoff input before the main playlist input", async () => {
+    const writeText = mockClipboard();
+    const handoffInput = `spotify:playlist:${playlistId}`;
     await act(async () =>
       root.render(
         <MobileDesktopHandoff
-          playlistInput={playlist}
+          handoffInput={handoffInput}
+          playlistInput={`https://open.spotify.com/playlist/${playlistId}`}
           focusPlaylistInput={vi.fn()}
         />,
       ),
     );
 
+    const copyButton = await clickCopy();
+
+    expect(writeText).toHaveBeenCalledWith(
+      `${window.location.origin}?playlist=${encodeURIComponent(handoffInput)}`,
+    );
+    expect(copyButton?.textContent).toBe("Copied");
+  });
+
+  test("falls back to the main playlist input", async () => {
+    const writeText = mockClipboard();
+    const playlistInput = `https://open.spotify.com/playlist/${playlistId}?si=abc`;
+    await act(async () =>
+      root.render(
+        <MobileDesktopHandoff
+          playlistInput={playlistInput}
+          focusPlaylistInput={vi.fn()}
+        />,
+      ),
+    );
+
+    await clickCopy();
+
+    expect(writeText).toHaveBeenCalledWith(
+      `${window.location.origin}?playlist=${encodeURIComponent(playlistInput)}`,
+    );
+  });
+
+  test("falls back to the current analyzed playlist source", async () => {
+    const writeText = mockClipboard();
+    const activePlaylistInput = `https://open.spotify.com/playlist/${playlistId}?si=analyzed`;
+    await act(async () =>
+      root.render(
+        <MobileDesktopHandoff
+          playlistInput=""
+          activePlaylistInput={activePlaylistInput}
+          focusPlaylistInput={vi.fn()}
+        />,
+      ),
+    );
+
+    expect(container.textContent).not.toContain(
+      "Paste a playlist first to create your desktop link.",
+    );
+    await clickCopy();
+    expect(writeText).toHaveBeenCalledWith(
+      `${window.location.origin}?playlist=${encodeURIComponent(activePlaylistInput)}`,
+    );
+  });
+
+  test("uses the resolved desktop link for Email to myself", async () => {
+    const activePlaylistInput = `spotify:playlist:${playlistId}`;
+    await act(async () =>
+      root.render(
+        <MobileDesktopHandoff
+          playlistInput=""
+          activePlaylistInput={activePlaylistInput}
+          focusPlaylistInput={vi.fn()}
+        />,
+      ),
+    );
+
+    const emailLink = Array.from(container.querySelectorAll("a")).find(
+      (link) => link.textContent === "Email to myself",
+    );
+    const desktopLink = `${window.location.origin}?playlist=${encodeURIComponent(activePlaylistInput)}`;
+    expect(decodeURIComponent(emailLink?.getAttribute("href") ?? "")).toContain(
+      desktopLink,
+    );
+  });
+
+  test("shows the empty message only when every playlist source is missing", async () => {
+    await act(async () =>
+      root.render(
+        <MobileDesktopHandoff
+          playlistInput=""
+          activePlaylistInput=""
+          queryPlaylist=""
+          focusPlaylistInput={vi.fn()}
+        />,
+      ),
+    );
+
+    expect(container.textContent).toContain(
+      "Paste a playlist first to create your desktop link.",
+    );
     const copyButton = Array.from(container.querySelectorAll("button")).find(
       (button) => button.textContent === "Copy desktop link",
     );
-    await act(async () => copyButton?.click());
-
-    expect(writeText).toHaveBeenCalledWith(
-      `${window.location.origin}?playlist=${encodeURIComponent(playlist)}`,
-    );
-    expect(copyButton?.textContent).toBe("Copied");
+    expect(copyButton?.disabled).toBe(true);
   });
 });


### PR DESCRIPTION
Fixes the mobile handoff panel so Copy desktop link uses the best available playlist source instead of only a separate empty handoff state.

Changes:
- Resolve handoff playlist source from handoff input, main input, active playlist, or query param
- Enable Copy desktop link when an analyzed playlist exists
- Reuse the same generated link for Email to myself
- Keep empty-state prompt only when no playlist source exists
- Add focused regression tests

Validation:
- pnpm test
- pnpm exec tsc --noEmit --incremental false
- pnpm lint
- pnpm build
- git diff --check
